### PR TITLE
chore: add Vercel config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "installCommand": "pnpm install",
+  "buildCommand": "pnpm build",
+  "functions": {
+    "nodeVersion": "18.x"
+  }
+}


### PR DESCRIPTION
## Summary
- add Vercel config to use pnpm for install and build
- set functions to use Node.js 18.x per package.json engines

## Testing
- `pnpm test` *(fails: Missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a3d1e8f483239b1397811e889f2e