### PR TITLE
chore: remove unused imports

### DIFF
--- a/src/components/ResearchModes/BulkCompanyResearch.tsx
+++ b/src/components/ResearchModes/BulkCompanyResearch.tsx
@@ -24,7 +24,7 @@
  */
 
 "use client";
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import dynamic from "next/dynamic";
 import { Button } from "@/components/ui/button";
@@ -34,22 +34,19 @@ import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
-import { 
-  Building2, 
-  Search, 
-  Loader2, 
-  CheckCircle2, 
-  XCircle, 
+import { Collapsible, CollapsibleContent } from "@/components/ui/collapsible";
+import {
+  Search,
+  Loader2,
+  CheckCircle2,
+  XCircle,
   Clock,
   ChevronDown,
   ChevronUp,
   AlertCircle,
-  FileText,
   Download,
   Users,
-  Upload,
-  X
+  Upload
 } from "lucide-react";
 import { Input } from "@/components/ui/input";
 
@@ -84,14 +81,12 @@ export default function BulkCompanyResearch() {
   
   // State management
   const [companyNames, setCompanyNames] = useState<string>(""); // Raw input from user
-  const [companies, setCompanies] = useState<string[]>([]); // Parsed company list
+  const [, setCompanies] = useState<string[]>([]); // Parsed company list
   const [isSearching, setIsSearching] = useState(false); // Are we currently researching?
   const [results, setResults] = useState<CompanyResult[]>([]); // Results for each company
   const [progress, setProgress] = useState<BulkProgress | null>(null); // Overall progress
   const [expandedCards, setExpandedCards] = useState<Set<string>>(new Set()); // Which cards are expanded
   
-  // Ref to store the EventSource for cleanup
-  const eventSourceRef = useRef<EventSource | null>(null);
 
   /**
    * Parse the input text to extract company names

--- a/src/components/Setting.tsx
+++ b/src/components/Setting.tsx
@@ -7,7 +7,7 @@ import {
   type ReactNode,
 } from "react";
 import { useTranslation } from "react-i18next";
-import { RefreshCw, CircleHelp, MonitorDown } from "lucide-react";
+import { RefreshCw, CircleHelp } from "lucide-react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { z } from "zod";

--- a/src/components/ui/collapsible.tsx
+++ b/src/components/ui/collapsible.tsx
@@ -1,12 +1,11 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as CollapsiblePrimitive from "@radix-ui/react-collapsible"
+import * as CollapsiblePrimitive from "@radix-ui/react-collapsible";
 
-const Collapsible = CollapsiblePrimitive.Root
+const Collapsible = CollapsiblePrimitive.Root;
 
-const CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger
+const CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger;
 
-const CollapsibleContent = CollapsiblePrimitive.CollapsibleContent
+const CollapsibleContent = CollapsiblePrimitive.CollapsibleContent;
 
-export { Collapsible, CollapsibleTrigger, CollapsibleContent }
+export { Collapsible, CollapsibleTrigger, CollapsibleContent };

--- a/src/hooks/useAiProvider.ts
+++ b/src/hooks/useAiProvider.ts
@@ -5,7 +5,6 @@ import {
 } from "@/utils/deep-research/provider";
 import {
   GEMINI_BASE_URL,
-  OPENROUTER_BASE_URL,
   OPENAI_BASE_URL,
   ANTHROPIC_BASE_URL,
 } from "@/constants/urls";

--- a/src/utils/company-deep-research/index.ts
+++ b/src/utils/company-deep-research/index.ts
@@ -494,9 +494,9 @@ Create a research plan that prioritizes the most important aspects for this spec
 Consider what's most relevant given the industry, competitive dynamics, and any specific context provided.
 
 Available research sections:
-${Object.entries(INVESTMENT_RESEARCH_SECTIONS).map(([_, section]) => 
-  `- ${section.title}: ${section.prompts[0]}`
-).join("\n")}
+${Object.entries(INVESTMENT_RESEARCH_SECTIONS)
+  .map(([, section]) => `- ${section.title}: ${section.prompts[0]}`)
+  .join("\n")}
 
 Provide a brief rationale for which sections should be prioritized and any company-specific focus areas.`;
 


### PR DESCRIPTION
## Summary
- drop unused `CollapsibleTrigger` and extra icons from bulk company research component
- clean up stray unused imports and variables across settings, collapsible helper, AI provider hook, and research utils

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68a7a8fea93c8323a69670ff4169eb77