### PR TITLE
refactor: centralize logging in development

### DIFF
--- a/docs/deep-research-api-doc.md
+++ b/docs/deep-research-api-doc.md
@@ -315,18 +315,22 @@ fetchEventSource("/api/sse", {
         report += msgData.text;
       }
     } else if (msg.event === "progress") {
-      console.log(
-        `[${data.step}]: ${msgData.name ? `${msgData.name} ` : ""}${
-          msgData.status
-        }`
-      );
-      if (msgData.data) console.log(msgData.data);
+      if (process.env.NODE_ENV !== "production") {
+        logger.log(
+          `[${data.step}]: ${msgData.name ? `${msgData.name} ` : ""}${
+            msgData.status
+          }`
+        );
+        if (msgData.data) logger.log(msgData.data);
+      }
     } else if (msg.event === "error") {
       throw new Error(msgData.message);
     }
   },
   onclose() {
-    console.log(report);
+    if (process.env.NODE_ENV !== "production") {
+      logger.log(report);
+    }
   },
 });
 ```

--- a/src/app/api/bulk-company-research/route.ts
+++ b/src/app/api/bulk-company-research/route.ts
@@ -24,6 +24,7 @@ import { NextRequest } from "next/server";
 import { CompanyDeepResearch } from "@/utils/company-deep-research";
 import { createSSEStream, getSSEHeaders } from "@/utils/sse";
 import { nanoid } from "nanoid";
+import { logger } from "@/utils/logger";
 
 // Define how many companies to research at the same time
 // Lower = less resource usage, Higher = faster completion
@@ -89,7 +90,7 @@ export async function POST(req: NextRequest) {
 
     // Step 3: Generate a unique ID for this bulk research session
     const bulkResearchId = nanoid();
-    console.log(`[Bulk Research ${bulkResearchId}] Starting research for ${body.companies.length} companies`);
+    logger.log(`[Bulk Research ${bulkResearchId}] Starting research for ${body.companies.length} companies`);
 
     // Step 4: Create the SSE stream for real-time updates
     const { stream, sendEvent, closeStream } = createSSEStream();
@@ -114,7 +115,7 @@ export async function POST(req: NextRequest) {
     // Step 6: Process companies in batches
     // This function runs the research for a single company
     const processCompany = async (companyName: string) => {
-      console.log(`[Bulk Research ${bulkResearchId}] Starting research for: ${companyName}`);
+      logger.log(`[Bulk Research ${bulkResearchId}] Starting research for: ${companyName}`);
       
       try {
         // Update status to processing
@@ -191,7 +192,7 @@ export async function POST(req: NextRequest) {
           result
         });
 
-        console.log(`[Bulk Research ${bulkResearchId}] Completed: ${companyName}`);
+        logger.log(`[Bulk Research ${bulkResearchId}] Completed: ${companyName}`);
 
       } catch (error) {
         console.error(`[Bulk Research ${bulkResearchId}] Error researching ${companyName}:`, error);
@@ -252,7 +253,7 @@ export async function POST(req: NextRequest) {
       }
     });
 
-    console.log(`[Bulk Research ${bulkResearchId}] All companies processed`);
+    logger.log(`[Bulk Research ${bulkResearchId}] All companies processed`);
 
     // Add a small delay before closing to ensure all events are sent
     await new Promise(resolve => setTimeout(resolve, 1000));

--- a/src/app/api/company-research/route.ts
+++ b/src/app/api/company-research/route.ts
@@ -25,6 +25,7 @@ import { NextRequest } from "next/server";
 import { CompanyDeepResearch } from "@/utils/company-deep-research";
 import { createSSEStream, getSSEHeaders } from "@/utils/sse";
 import { nanoid } from "nanoid";
+import { logger } from "@/utils/logger";
 
 // Define the shape of our request body for TypeScript type safety
 interface CompanyResearchRequest {
@@ -86,7 +87,7 @@ export async function POST(req: NextRequest) {
     // Step 3: Generate a unique ID for this research session
     // This helps track the research in logs and for debugging
     const researchId = nanoid();
-    console.log(`[Company Research ${researchId}] Starting research for: ${body.companyName}`);
+    logger.log(`[Company Research ${researchId}] Starting research for: ${body.companyName}`);
 
     // Step 4: Create the SSE (Server-Sent Events) stream
     // SSE allows us to send real-time updates to the client as research progresses
@@ -151,21 +152,21 @@ export async function POST(req: NextRequest) {
         case "fast":
           // Fast mode: Direct AI response, no web searches
           // Perfect for quick overviews or when you're in a hurry
-          console.log(`[Company Research ${researchId}] Running fast research`);
+          logger.log(`[Company Research ${researchId}] Running fast research`);
           result = await researcher.runFastResearch();
           break;
           
         case "medium":
           // Medium mode: Limited searches focusing on key areas
           // Good balance between speed and depth
-          console.log(`[Company Research ${researchId}] Running medium research`);
+          logger.log(`[Company Research ${researchId}] Running medium research`);
           result = await researcher.runMediumResearch();
           break;
           
         case "deep":
           // Deep mode: Comprehensive research with all investment sections
           // Use this when preparing for important meetings or decisions
-          console.log(`[Company Research ${researchId}] Running deep research`);
+          logger.log(`[Company Research ${researchId}] Running deep research`);
           result = await researcher.runDeepResearch();
           break;
           
@@ -187,7 +188,7 @@ export async function POST(req: NextRequest) {
         }
       });
 
-      console.log(`[Company Research ${researchId}] Research completed successfully`);
+      logger.log(`[Company Research ${researchId}] Research completed successfully`);
       
     } catch (error) {
       // Handle any errors during research

--- a/src/app/api/mcp/server.ts
+++ b/src/app/api/mcp/server.ts
@@ -8,6 +8,7 @@ import {
   getSearchProviderBaseURL,
   getSearchProviderApiKey,
 } from "../utils";
+import { logger } from "@/utils/logger";
 
 const AI_PROVIDER = process.env.MCP_AI_PROVIDER || "";
 const SEARCH_PROVIDER = process.env.MCP_SEARCH_PROVIDER || "model";
@@ -38,11 +39,11 @@ function initDeepResearchServer({
     },
     onMessage: (event, data) => {
       if (event === "progress") {
-        console.log(
+        logger.log(
           `[${data.step}]: ${data.name ? `"${data.name}" ` : ""}${data.status}`
         );
         if (data.status === "end" && data.data) {
-          console.log(data.data);
+          logger.log(data.data);
         }
       } else if (event === "error") {
         console.error(data.message);

--- a/src/app/api/sse/live/route.ts
+++ b/src/app/api/sse/live/route.ts
@@ -7,6 +7,7 @@ import {
   getSearchProviderBaseURL,
   getSearchProviderApiKey,
 } from "../../utils";
+import { logger } from "@/utils/logger";
 
 export const runtime = "edge";
 export const dynamic = "force-dynamic";
@@ -40,10 +41,10 @@ export async function GET(req: NextRequest) {
   const encoder = new TextEncoder();
   const readableStream = new ReadableStream({
     start: async (controller) => {
-      console.log("Client connected");
+      logger.log("Client connected");
 
       req.signal.addEventListener("abort", () => {
-        console.log("Client disconnected");
+        logger.log("Client disconnected");
       });
 
       const deepResearch = new DeepResearch({
@@ -65,7 +66,7 @@ export async function GET(req: NextRequest) {
           if (event === "message") {
             controller.enqueue(encoder.encode(data.text));
           } else if (event === "progress") {
-            console.log(
+            logger.log(
               `[${data.step}]: ${data.name ? `"${data.name}" ` : ""}${
                 data.status
               }`

--- a/src/app/api/sse/route.ts
+++ b/src/app/api/sse/route.ts
@@ -7,6 +7,7 @@ import {
   getSearchProviderBaseURL,
   getSearchProviderApiKey,
 } from "../utils";
+import { logger } from "@/utils/logger";
 
 export const runtime = "edge";
 export const dynamic = "force-dynamic";
@@ -37,7 +38,7 @@ export async function POST(req: NextRequest) {
   const encoder = new TextEncoder();
   const readableStream = new ReadableStream({
     start: async (controller) => {
-      console.log("Client connected");
+      logger.log("Client connected");
       controller.enqueue(
         encoder.encode(
           `event: infor\ndata: ${JSON.stringify({
@@ -64,7 +65,7 @@ export async function POST(req: NextRequest) {
         },
         onMessage: (event, data) => {
           if (event === "progress") {
-            console.log(
+            logger.log(
               `[${data.step}]: ${data.name ? `"${data.name}" ` : ""}${
                 data.status
               }`

--- a/src/components/ResearchModes/BulkCompanyResearch.tsx
+++ b/src/components/ResearchModes/BulkCompanyResearch.tsx
@@ -49,6 +49,7 @@ import {
   Upload
 } from "lucide-react";
 import { Input } from "@/components/ui/input";
+import { logger } from "@/utils/logger";
 
 // Import MagicDown for rendering markdown
 const MagicDown = dynamic(() => import("@/components/MagicDown"));
@@ -216,7 +217,7 @@ export default function BulkCompanyResearch() {
             if (dataLine) {
               try {
                 const data = JSON.parse(dataLine.substring(6));
-                console.log(`SSE Event: ${eventType}`, data); // Debug logging
+                logger.log(`SSE Event: ${eventType}`, data); // Debug logging
                 
                 // Handle different event types
                 switch (eventType) {
@@ -269,7 +270,7 @@ export default function BulkCompanyResearch() {
                       
                     case "complete":
                       // All companies processed
-                      console.log("Bulk research complete:", data);
+                      logger.log("Bulk research complete:", data);
                       setIsSearching(false);
                       break;
                       

--- a/src/components/ResearchModes/CompanyDeepDive.tsx
+++ b/src/components/ResearchModes/CompanyDeepDive.tsx
@@ -17,6 +17,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { downloadFile } from "@/utils/file";
+import { logger } from "@/utils/logger";
 
 const MagicDown = dynamic(() => import("@/components/MagicDown"));
 
@@ -161,17 +162,17 @@ export default function CompanyDeepDive() {
               // Handle different event types
               switch (eventType) {
                 case "progress":
-                  console.log("Progress:", data);
+                  logger.log("Progress:", data);
                   // You could update a progress indicator here
                   break;
-                  
+
                 case "message":
-                  console.log("Message:", data);
+                  logger.log("Message:", data);
                   // You could stream partial results here
                   break;
-                  
+
                 case "complete":
-                  console.log("Research complete:", data);
+                  logger.log("Research complete:", data);
                   setSearchResults(data);
                   setIsSearching(false);
                   break;

--- a/src/hooks/useDeepResearch.ts
+++ b/src/hooks/useDeepResearch.ts
@@ -29,6 +29,7 @@ import { isNetworkingModel } from "@/utils/model";
 import { ThinkTagStreamProcessor, removeJsonMarkdown } from "@/utils/text";
 import { parseError } from "@/utils/error";
 import { pick, flat, unique } from "radash";
+import { logger } from "@/utils/logger";
 
 type ProviderOptions = Record<string, Record<string, JSONValue>>;
 type Tools = Record<string, Tool>;
@@ -91,7 +92,7 @@ function useDeepResearch() {
         reasoning += part.textDelta;
       }
     }
-    if (reasoning) console.log(reasoning);
+    if (reasoning) logger.log(reasoning);
   }
 
   async function writeReportPlan() {
@@ -126,7 +127,7 @@ function useDeepResearch() {
         reasoning += part.textDelta;
       }
     }
-    if (reasoning) console.log(reasoning);
+    if (reasoning) logger.log(reasoning);
     return content;
   }
 
@@ -174,7 +175,7 @@ function useDeepResearch() {
         reasoning += part.textDelta;
       }
     }
-    if (reasoning) console.log(reasoning);
+    if (reasoning) logger.log(reasoning);
     return content;
   }
 
@@ -395,7 +396,7 @@ function useDeepResearch() {
               }
             }
           }
-          if (reasoning) console.log(reasoning);
+          if (reasoning) logger.log(reasoning);
 
           if (sources.length > 0) {
             content +=
@@ -481,7 +482,7 @@ function useDeepResearch() {
         }
       );
     }
-    if (reasoning) console.log(reasoning);
+    if (reasoning) logger.log(reasoning);
     if (queries.length > 0) {
       taskStore.update([...tasks, ...queries]);
       await runSearchTask(queries);
@@ -555,7 +556,7 @@ function useDeepResearch() {
         reasoning += part.textDelta;
       }
     }
-    if (reasoning) console.log(reasoning);
+    if (reasoning) logger.log(reasoning);
     if (sources.length > 0) {
       content +=
         "\n\n" +
@@ -637,7 +638,7 @@ function useDeepResearch() {
           }
         );
       }
-      if (reasoning) console.log(reasoning);
+      if (reasoning) logger.log(reasoning);
       await runSearchTask(queries);
     } catch (err) {
       console.error(err);

--- a/src/hooks/useKnowledge.ts
+++ b/src/hooks/useKnowledge.ts
@@ -16,6 +16,7 @@ import {
 } from "@/utils/text";
 import { parseError } from "@/utils/error";
 import { omit } from "radash";
+import { logger } from "@/utils/logger";
 
 const MAX_CHUNK_LENGTH = 10000;
 
@@ -116,7 +117,7 @@ function useKnowledge() {
           reasoning += part.textDelta;
         }
       }
-      if (reasoning) console.log(reasoning);
+      if (reasoning) logger.log(reasoning);
       return content;
     }
 

--- a/src/libs/mcp-server/streamableHttp.ts
+++ b/src/libs/mcp-server/streamableHttp.ts
@@ -88,12 +88,12 @@ const nanoid = customAlphabet("1234567890abcdef");
  *   // sessionIdGenerator: undefined, // Stateless mode
  *   enableJsonResponse: false, // Or true for JSON-only responses
  *   // eventStore: myEventStore, // Optional resumability
- *   onsessioninitialized: (id) => console.log('Session initialized:', id)
+ *   onsessioninitialized: (id) => logger.log('Session initialized:', id)
  * });
  *
  * // Implement your message handling logic
  * transport.onmessage = async (message, { authInfo }) => {
- *   console.log('Received message:', message, 'Auth:', authInfo);
+ *   logger.log('Received message:', message, 'Auth:', authInfo);
  *   // Process the message and potentially send responses/notifications back
  *   if (message.id !== undefined) { // It's a request or response/error with ID
  *      // Example: Echo back a response for requests
@@ -122,7 +122,7 @@ const nanoid = customAlphabet("1234567890abcdef");
  * };
  *
  * transport.onclose = () => {
- *   console.log('Transport closed.');
+ *   logger.log('Transport closed.');
  * };
  *
  * // Start the transport (no-op for HTTP but good practice)

--- a/src/utils/company-deep-research/index.ts
+++ b/src/utils/company-deep-research/index.ts
@@ -38,6 +38,7 @@ import {
 import { streamText, generateText } from "ai";
 import { createAIProvider } from "@/utils/deep-research/provider";
 import { createSearchProvider } from "@/utils/deep-research/search";
+import { logger } from "@/utils/logger";
 import { ThinkTagStreamProcessor } from "@/utils/text";
 // Removed unused import: pick from radash
 
@@ -114,10 +115,14 @@ export class CompanyDeepResearch {
     this.config = config;
     
     // Debug: Check if imports are loaded
-    console.log("CompanyDeepResearch constructor - Checking imports:");
-    console.log("systemInstruction:", typeof systemInstruction, systemInstruction?.substring(0, 50) + "...");
-    console.log("outputGuidelinesPrompt:", typeof outputGuidelinesPrompt, outputGuidelinesPrompt?.substring(0, 50) + "...");
-    console.log("INVESTMENT_RESEARCH_SECTIONS:", typeof INVESTMENT_RESEARCH_SECTIONS, Object.keys(INVESTMENT_RESEARCH_SECTIONS || {}));
+    logger.log("CompanyDeepResearch constructor - Checking imports:");
+    logger.log("systemInstruction:", typeof systemInstruction, systemInstruction?.substring(0, 50) + "...");
+    logger.log("outputGuidelinesPrompt:", typeof outputGuidelinesPrompt, outputGuidelinesPrompt?.substring(0, 50) + "...");
+    logger.log(
+      "INVESTMENT_RESEARCH_SECTIONS:",
+      typeof INVESTMENT_RESEARCH_SECTIONS,
+      Object.keys(INVESTMENT_RESEARCH_SECTIONS || {})
+    );
   }
   
   /**
@@ -508,7 +513,7 @@ Provide a brief rationale for which sections should be prioritized and any compa
       });
       
       // Log the plan rationale for debugging
-      console.log("Research plan rationale:", planRationale);
+      logger.log("Research plan rationale:", planRationale);
       
       // Build the structured plan with all sections but customized priorities
       const plan = {
@@ -708,7 +713,7 @@ Provide a brief rationale for which sections should be prioritized and any compa
         const searchResult = await this.searchProvider(task.query);
         
         if (!searchResult || !searchResult.sources || searchResult.sources.length === 0) {
-          console.log(`No results for query: ${task.query}`);
+          logger.log(`No results for query: ${task.query}`);
           continue;
         }
         

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,7 @@
+export const logger = {
+  log: (...args: unknown[]) => {
+    if (process.env.NODE_ENV !== 'production') {
+      console.log(...args);
+    }
+  },
+};

--- a/src/utils/sse.ts
+++ b/src/utils/sse.ts
@@ -25,6 +25,8 @@
  * - Add reconnection logic: Implement EventSource retry on client side
  */
 
+import { logger } from "@/utils/logger";
+
 /**
  * Creates an SSE stream with helper functions
  * 
@@ -62,7 +64,7 @@ export function createSSEStream() {
     
     // Called when the client disconnects or we close the stream
     cancel() {
-      console.log("SSE stream cancelled by client");
+      logger.log("SSE stream cancelled by client");
       isStreamActive = false;
     }
   });
@@ -96,7 +98,7 @@ export function createSSEStream() {
       streamController.enqueue(encoder.encode(formattedEvent));
       
       // Log for debugging (remove in production for performance)
-      console.log(`SSE event sent: ${eventName}`, data);
+      logger.log(`SSE event sent: ${eventName}`, data);
     } catch (error) {
       console.error(`Error sending SSE event "${eventName}":`, error);
       // Don't throw here - we don't want one failed event to break the stream
@@ -119,7 +121,7 @@ export function createSSEStream() {
         // Close the stream controller
         streamController.close();
         isStreamActive = false;
-        console.log("SSE stream closed successfully");
+        logger.log("SSE stream closed successfully");
       } catch (error) {
         console.error("Error closing SSE stream:", error);
       }


### PR DESCRIPTION
## Summary
- add `logger` utility that suppresses logs in production
- replace scattered `console.log` calls with centralized logger usage
- update docs to show environment-safe logging

## Testing
- `pnpm lint`
- `pnpm run test` *(fails: Missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ad3de9f08323845ff1113df1fe4f