### PR TITLE
chore: centralize environment config

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,46 +1,47 @@
 import type { NextConfig } from "next";
 import pkg from "./package.json";
+import { env } from "./src/utils/env";
 
 // AI provider API base url
-const API_PROXY_BASE_URL = process.env.API_PROXY_BASE_URL || "";
+const API_PROXY_BASE_URL = env.API_PROXY_BASE_URL || "";
 const GOOGLE_GENERATIVE_AI_API_BASE_URL =
-  process.env.GOOGLE_GENERATIVE_AI_API_BASE_URL ||
+  env.GOOGLE_GENERATIVE_AI_API_BASE_URL ||
   "https://generativelanguage.googleapis.com";
 const OPENROUTER_API_BASE_URL =
-  process.env.OPENROUTER_API_BASE_URL || "https://openrouter.ai/api";
+  env.OPENROUTER_API_BASE_URL || "https://openrouter.ai/api";
 const OPENAI_API_BASE_URL =
-  process.env.OPENAI_API_BASE_URL || "https://api.openai.com";
+  env.OPENAI_API_BASE_URL || "https://api.openai.com";
 const ANTHROPIC_API_BASE_URL =
-  process.env.ANTHROPIC_API_BASE_URL || "https://api.anthropic.com";
+  env.ANTHROPIC_API_BASE_URL || "https://api.anthropic.com";
 const DEEPSEEK_API_BASE_URL =
-  process.env.DEEPSEEK_API_BASE_URL || "https://api.deepseek.com";
-const XAI_API_BASE_URL = process.env.XAI_API_BASE_URL || "https://api.x.ai";
+  env.DEEPSEEK_API_BASE_URL || "https://api.deepseek.com";
+const XAI_API_BASE_URL = env.XAI_API_BASE_URL || "https://api.x.ai";
 const MISTRAL_API_BASE_URL =
-  process.env.MISTRAL_API_BASE_URL || "https://api.mistral.ai";
-const AZURE_API_BASE_URL = `https://${process.env.AZURE_RESOURCE_NAME}.openai.azure.com/openai/deployments`;
+  env.MISTRAL_API_BASE_URL || "https://api.mistral.ai";
+const AZURE_API_BASE_URL = `https://${env.AZURE_RESOURCE_NAME}.openai.azure.com/openai/deployments`;
 const OPENAI_COMPATIBLE_API_BASE_URL =
-  process.env.OPENAI_COMPATIBLE_API_BASE_URL || "";
+  env.OPENAI_COMPATIBLE_API_BASE_URL || "";
 const POLLINATIONS_API_BASE_URL =
-  process.env.POLLINATIONS_API_BASE_URL ||
+  env.POLLINATIONS_API_BASE_URL ||
   "https://text.pollinations.ai/openai";
 const OLLAMA_API_BASE_URL =
-  process.env.OLLAMA_API_BASE_URL || "http://0.0.0.0:11434";
+  env.OLLAMA_API_BASE_URL || "http://0.0.0.0:11434";
 // Search provider API base url
 const TAVILY_API_BASE_URL =
-  process.env.TAVILY_API_BASE_URL || "https://api.tavily.com";
+  env.TAVILY_API_BASE_URL || "https://api.tavily.com";
 const FIRECRAWL_API_BASE_URL =
-  process.env.FIRECRAWL_API_BASE_URL || "https://api.firecrawl.dev";
-const EXA_API_BASE_URL = process.env.EXA_API_BASE_URL || "https://api.exa.ai";
+  env.FIRECRAWL_API_BASE_URL || "https://api.firecrawl.dev";
+const EXA_API_BASE_URL = env.EXA_API_BASE_URL || "https://api.exa.ai";
 const BOCHA_API_BASE_URL =
-  process.env.BOCHA_API_BASE_URL || "https://api.bochaai.com";
+  env.BOCHA_API_BASE_URL || "https://api.bochaai.com";
 const SEARXNG_API_BASE_URL =
-  process.env.SEARXNG_API_BASE_URL || "http://0.0.0.0:8080";
+  env.SEARXNG_API_BASE_URL || "http://0.0.0.0:8080";
 
 export default async function Config(phase: string) {
   const nextConfig: NextConfig = {
     /* config options here */
     experimental: {
-      reactCompiler: process.env.REACT_COMPILER === "true",
+      reactCompiler: env.REACT_COMPILER === "true",
     },
     env: {
       NEXT_PUBLIC_VERSION: pkg.version,

--- a/src/app/api/ai/anthropic/[...slug]/route.ts
+++ b/src/app/api/ai/anthropic/[...slug]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { ANTHROPIC_BASE_URL } from "@/constants/urls";
+import { env } from "@/utils/env";
 
 export const runtime = "edge";
 export const preferredRegion = [
@@ -14,7 +15,7 @@ export const preferredRegion = [
 ];
 
 const API_PROXY_BASE_URL =
-  process.env.ANTHROPIC_API_BASE_URL || ANTHROPIC_BASE_URL;
+  env.ANTHROPIC_API_BASE_URL || ANTHROPIC_BASE_URL;
 
 async function handler(req: NextRequest) {
   let body;

--- a/src/app/api/ai/azure/[...slug]/route.ts
+++ b/src/app/api/ai/azure/[...slug]/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse, type NextRequest } from "next/server";
+import { env } from "@/utils/env";
 
 export const runtime = "edge";
 export const preferredRegion = [
@@ -12,8 +13,8 @@ export const preferredRegion = [
   "kix1",
 ];
 
-const API_PROXY_BASE_URL = `https://${process.env.AZURE_RESOURCE_NAME}.openai.azure.com/openai/deployments`;
-const API_VERSION = process.env.AZURE_API_VERSION || "";
+const API_PROXY_BASE_URL = `https://${env.AZURE_RESOURCE_NAME}.openai.azure.com/openai/deployments`;
+const API_VERSION = env.AZURE_API_VERSION || "";
 
 async function handler(req: NextRequest) {
   let body;

--- a/src/app/api/ai/google/[...slug]/route.ts
+++ b/src/app/api/ai/google/[...slug]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { GEMINI_BASE_URL } from "@/constants/urls";
+import { env } from "@/utils/env";
 
 export const runtime = "edge";
 export const preferredRegion = [
@@ -14,8 +15,8 @@ export const preferredRegion = [
 ];
 
 const API_PROXY_BASE_URL =
-  process.env.API_PROXY_BASE_URL ||
-  process.env.GOOGLE_GENERATIVE_AI_API_BASE_URL ||
+  env.API_PROXY_BASE_URL ||
+  env.GOOGLE_GENERATIVE_AI_API_BASE_URL ||
   GEMINI_BASE_URL;
 
 async function handler(req: NextRequest) {

--- a/src/app/api/ai/openai/[...slug]/route.ts
+++ b/src/app/api/ai/openai/[...slug]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { OPENAI_BASE_URL } from "@/constants/urls";
+import { env } from "@/utils/env";
 
 export const runtime = "edge";
 export const preferredRegion = [
@@ -13,7 +14,7 @@ export const preferredRegion = [
   "kix1",
 ];
 
-const API_PROXY_BASE_URL = process.env.OPENAI_API_BASE_URL || OPENAI_BASE_URL;
+const API_PROXY_BASE_URL = env.OPENAI_API_BASE_URL || OPENAI_BASE_URL;
 
 async function handler(req: NextRequest) {
   let body;

--- a/src/app/api/bulk-company-research/route.ts
+++ b/src/app/api/bulk-company-research/route.ts
@@ -24,6 +24,7 @@ import { NextRequest } from "next/server";
 import { CompanyDeepResearch } from "@/utils/company-deep-research";
 import { createSSEStream, getSSEHeaders } from "@/utils/sse";
 import { nanoid } from "nanoid";
+import { env } from "@/utils/env";
 
 // Define how many companies to research at the same time
 // Lower = less resource usage, Higher = faster completion
@@ -62,7 +63,7 @@ export async function POST(req: NextRequest) {
   try {
     // Step 1: Check for ACCESS_PASSWORD if configured
     // This protects your API from unauthorized use
-    const accessPassword = process.env.ACCESS_PASSWORD;
+    const accessPassword = env.ACCESS_PASSWORD;
     if (accessPassword) {
       const authHeader = req.headers.get("Authorization");
       const providedPassword = authHeader?.replace("Bearer ", "") || 

--- a/src/app/api/company-research/route.ts
+++ b/src/app/api/company-research/route.ts
@@ -25,6 +25,7 @@ import { NextRequest } from "next/server";
 import { CompanyDeepResearch } from "@/utils/company-deep-research";
 import { createSSEStream, getSSEHeaders } from "@/utils/sse";
 import { nanoid } from "nanoid";
+import { env } from "@/utils/env";
 
 // Define the shape of our request body for TypeScript type safety
 interface CompanyResearchRequest {
@@ -61,7 +62,7 @@ export async function POST(req: NextRequest) {
   try {
     // Step 1: Check for ACCESS_PASSWORD if configured
     // This is a simple way to protect your API endpoint
-    const accessPassword = process.env.ACCESS_PASSWORD;
+    const accessPassword = env.ACCESS_PASSWORD;
     if (accessPassword) {
       // Get the password from the Authorization header or query parameter
       const authHeader = req.headers.get("Authorization");

--- a/src/app/api/mcp/server.ts
+++ b/src/app/api/mcp/server.ts
@@ -8,11 +8,12 @@ import {
   getSearchProviderBaseURL,
   getSearchProviderApiKey,
 } from "../utils";
+import { env } from "@/utils/env";
 
-const AI_PROVIDER = process.env.MCP_AI_PROVIDER || "";
-const SEARCH_PROVIDER = process.env.MCP_SEARCH_PROVIDER || "model";
-const THINKING_MODEL = process.env.MCP_THINKING_MODEL || "";
-const TASK_MODEL = process.env.MCP_TASK_MODEL || "";
+const AI_PROVIDER = env.MCP_AI_PROVIDER || "";
+const SEARCH_PROVIDER = env.MCP_SEARCH_PROVIDER || "model";
+const THINKING_MODEL = env.MCP_THINKING_MODEL || "";
+const TASK_MODEL = env.MCP_TASK_MODEL || "";
 
 function initDeepResearchServer({
   language,

--- a/src/app/api/search/exa/[...slug]/route.ts
+++ b/src/app/api/search/exa/[...slug]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { EXA_BASE_URL } from "@/constants/urls";
+import { env } from "@/utils/env";
 
 export const runtime = "edge";
 export const preferredRegion = [
@@ -13,7 +14,7 @@ export const preferredRegion = [
   "kix1",
 ];
 
-const API_PROXY_BASE_URL = process.env.EXA_API_BASE_URL || EXA_BASE_URL;
+const API_PROXY_BASE_URL = env.EXA_API_BASE_URL || EXA_BASE_URL;
 
 export async function POST(req: NextRequest) {
   const body = await req.json();

--- a/src/app/api/search/firecrawl/[...slug]/route.ts
+++ b/src/app/api/search/firecrawl/[...slug]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { FIRECRAWL_BASE_URL } from "@/constants/urls";
+import { env } from "@/utils/env";
 
 export const runtime = "edge";
 export const preferredRegion = [
@@ -14,7 +15,7 @@ export const preferredRegion = [
 ];
 
 const API_PROXY_BASE_URL =
-  process.env.FIRECRAWL_API_BASE_URL || FIRECRAWL_BASE_URL;
+  env.FIRECRAWL_API_BASE_URL || FIRECRAWL_BASE_URL;
 
 export async function POST(req: NextRequest) {
   const body = await req.json();

--- a/src/app/api/search/tavily/[...slug]/route.ts
+++ b/src/app/api/search/tavily/[...slug]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { TAVILY_BASE_URL } from "@/constants/urls";
+import { env } from "@/utils/env";
 
 export const runtime = "edge";
 export const preferredRegion = [
@@ -13,7 +14,7 @@ export const preferredRegion = [
   "kix1",
 ];
 
-const API_PROXY_BASE_URL = process.env.TAVILY_API_BASE_URL || TAVILY_BASE_URL;
+const API_PROXY_BASE_URL = env.TAVILY_API_BASE_URL || TAVILY_BASE_URL;
 
 export async function POST(req: NextRequest) {
   const body = await req.json();

--- a/src/app/api/utils.ts
+++ b/src/app/api/utils.ts
@@ -1,54 +1,55 @@
 import { completePath } from "@/utils/url";
+import { env } from "@/utils/env";
 
 // AI provider API base url
 const GOOGLE_GENERATIVE_AI_API_BASE_URL =
-  process.env.GOOGLE_GENERATIVE_AI_API_BASE_URL ||
+  env.GOOGLE_GENERATIVE_AI_API_BASE_URL ||
   "https://generativelanguage.googleapis.com";
 const OPENROUTER_API_BASE_URL =
-  process.env.OPENROUTER_API_BASE_URL || "https://openrouter.ai/api";
+  env.OPENROUTER_API_BASE_URL || "https://openrouter.ai/api";
 const OPENAI_API_BASE_URL =
-  process.env.OPENAI_API_BASE_URL || "https://api.openai.com";
+  env.OPENAI_API_BASE_URL || "https://api.openai.com";
 const ANTHROPIC_API_BASE_URL =
-  process.env.ANTHROPIC_API_BASE_URL || "https://api.anthropic.com";
+  env.ANTHROPIC_API_BASE_URL || "https://api.anthropic.com";
 const DEEPSEEK_API_BASE_URL =
-  process.env.DEEPSEEK_API_BASE_URL || "https://api.deepseek.com";
-const XAI_API_BASE_URL = process.env.XAI_API_BASE_URL || "https://api.x.ai";
+  env.DEEPSEEK_API_BASE_URL || "https://api.deepseek.com";
+const XAI_API_BASE_URL = env.XAI_API_BASE_URL || "https://api.x.ai";
 const MISTRAL_API_BASE_URL =
-  process.env.MISTRAL_API_BASE_URL || "https://api.mistral.ai";
-const AZURE_API_BASE_URL = `https://${process.env.AZURE_RESOURCE_NAME}.openai.azure.com/openai/deployments`;
+  env.MISTRAL_API_BASE_URL || "https://api.mistral.ai";
+const AZURE_API_BASE_URL = `https://${env.AZURE_RESOURCE_NAME}.openai.azure.com/openai/deployments`;
 const OPENAI_COMPATIBLE_API_BASE_URL =
-  process.env.OPENAI_COMPATIBLE_API_BASE_URL || "";
+  env.OPENAI_COMPATIBLE_API_BASE_URL || "";
 const POLLINATIONS_API_BASE_URL =
-  process.env.POLLINATIONS_API_BASE_URL ||
+  env.POLLINATIONS_API_BASE_URL ||
   "https://text.pollinations.ai/openai";
 const OLLAMA_API_BASE_URL =
-  process.env.OLLAMA_API_BASE_URL || "http://0.0.0.0:11434";
+  env.OLLAMA_API_BASE_URL || "http://0.0.0.0:11434";
 // Search provider API base url
 const TAVILY_API_BASE_URL =
-  process.env.TAVILY_API_BASE_URL || "https://api.tavily.com";
+  env.TAVILY_API_BASE_URL || "https://api.tavily.com";
 const FIRECRAWL_API_BASE_URL =
-  process.env.FIRECRAWL_API_BASE_URL || "https://api.firecrawl.dev";
-const EXA_API_BASE_URL = process.env.EXA_API_BASE_URL || "https://api.exa.ai";
+  env.FIRECRAWL_API_BASE_URL || "https://api.firecrawl.dev";
+const EXA_API_BASE_URL = env.EXA_API_BASE_URL || "https://api.exa.ai";
 const BOCHA_API_BASE_URL =
-  process.env.BOCHA_API_BASE_URL || "https://api.bochaai.com";
+  env.BOCHA_API_BASE_URL || "https://api.bochaai.com";
 const SEARXNG_API_BASE_URL =
-  process.env.SEARXNG_API_BASE_URL || "http://0.0.0.0:8080";
+  env.SEARXNG_API_BASE_URL || "http://0.0.0.0:8080";
 
 const GOOGLE_GENERATIVE_AI_API_KEY =
-  process.env.GOOGLE_GENERATIVE_AI_API_KEY || "";
-const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY || "";
-const OPENAI_API_KEY = process.env.OPENAI_API_KEY || "";
-const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY || "";
-const DEEPSEEK_API_KEY = process.env.DEEPSEEK_API_KEY || "";
-const XAI_API_KEY = process.env.XAI_API_KEY || "";
-const MISTRAL_API_KEY = process.env.MISTRAL_API_KEY || "";
-const AZURE_API_KEY = process.env.AZURE_API_KEY || "";
-const OPENAI_COMPATIBLE_API_KEY = process.env.OPENAI_COMPATIBLE_API_KEY || "";
+  env.GOOGLE_GENERATIVE_AI_API_KEY || "";
+const OPENROUTER_API_KEY = env.OPENROUTER_API_KEY || "";
+const OPENAI_API_KEY = env.OPENAI_API_KEY || "";
+const ANTHROPIC_API_KEY = env.ANTHROPIC_API_KEY || "";
+const DEEPSEEK_API_KEY = env.DEEPSEEK_API_KEY || "";
+const XAI_API_KEY = env.XAI_API_KEY || "";
+const MISTRAL_API_KEY = env.MISTRAL_API_KEY || "";
+const AZURE_API_KEY = env.AZURE_API_KEY || "";
+const OPENAI_COMPATIBLE_API_KEY = env.OPENAI_COMPATIBLE_API_KEY || "";
 // Search provider API key
-const TAVILY_API_KEY = process.env.TAVILY_API_KEY || "";
-const FIRECRAWL_API_KEY = process.env.FIRECRAWL_API_KEY || "";
-const EXA_API_KEY = process.env.EXA_API_KEY || "";
-const BOCHA_API_KEY = process.env.BOCHA_API_KEY || "";
+const TAVILY_API_KEY = env.TAVILY_API_KEY || "";
+const FIRECRAWL_API_KEY = env.FIRECRAWL_API_KEY || "";
+const EXA_API_KEY = env.EXA_API_KEY || "";
+const BOCHA_API_KEY = env.BOCHA_API_KEY || "";
 
 export function getAIProviderBaseURL(provider: string) {
   switch (provider) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,10 +4,11 @@ import ThemeProvider from "@/components/Provider/Theme";
 import I18Provider from "@/components/Provider/I18n";
 import Debugger from "@/components/Internal/Debugger";
 import { Toaster } from "@/components/ui/sonner";
+import { env } from "@/utils/env";
 
 import "./globals.css";
 
-const HEAD_SCRIPTS = process.env.HEAD_SCRIPTS as string;
+const HEAD_SCRIPTS = env.HEAD_SCRIPTS as string | undefined;
 const APP_NAME = "TD Deep Research";
 const APP_DEFAULT_TITLE = "TD Deep Research";
 const APP_TITLE_TEMPLATE = "%s - PWA App";

--- a/src/components/Internal/Header.tsx
+++ b/src/components/Internal/Header.tsx
@@ -3,8 +3,9 @@ import { useTranslation } from "react-i18next";
 import { Settings, Github, History, BookText } from "lucide-react";
 import { Button } from "@/components/Internal/Button";
 import { useGlobalStore } from "@/store/global";
+import { env } from "@/utils/env";
 
-const VERSION = process.env.NEXT_PUBLIC_VERSION;
+const VERSION = env.NEXT_PUBLIC_VERSION;
 
 function Header() {
   const { t } = useTranslation();

--- a/src/components/Knowledge/Crawler.tsx
+++ b/src/components/Knowledge/Crawler.tsx
@@ -24,13 +24,14 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import useKnowledge from "@/hooks/useKnowledge";
 import { useSettingStore } from "@/store/setting";
+import { env } from "@/utils/env";
 
 type Props = {
   open: boolean;
   onClose: () => void;
 };
 
-const BUILD_MODE = process.env.NEXT_PUBLIC_BUILD_MODE;
+const BUILD_MODE = env.NEXT_PUBLIC_BUILD_MODE;
 const URLRegExp = /^https?:\/\/.+/;
 
 const formSchema = z.object({

--- a/src/components/ResearchModes/BulkCompanyResearch.tsx
+++ b/src/components/ResearchModes/BulkCompanyResearch.tsx
@@ -49,6 +49,7 @@ import {
   Upload
 } from "lucide-react";
 import { Input } from "@/components/ui/input";
+import { env } from "@/utils/env";
 
 // Import MagicDown for rendering markdown
 const MagicDown = dynamic(() => import("@/components/MagicDown"));
@@ -156,8 +157,8 @@ export default function BulkCompanyResearch() {
         headers: {
           "Content-Type": "application/json",
           // Add authorization header if ACCESS_PASSWORD is configured
-          ...(process.env.NEXT_PUBLIC_ACCESS_PASSWORD && {
-            Authorization: `Bearer ${process.env.NEXT_PUBLIC_ACCESS_PASSWORD}`
+          ...(env.NEXT_PUBLIC_ACCESS_PASSWORD && {
+            Authorization: `Bearer ${env.NEXT_PUBLIC_ACCESS_PASSWORD}`
           })
         },
         body: JSON.stringify(requestBody),

--- a/src/components/ResearchModes/CompanyDeepDive.tsx
+++ b/src/components/ResearchModes/CompanyDeepDive.tsx
@@ -17,6 +17,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { downloadFile } from "@/utils/file";
+import { env } from "@/utils/env";
 
 const MagicDown = dynamic(() => import("@/components/MagicDown"));
 
@@ -122,8 +123,8 @@ export default function CompanyDeepDive() {
         headers: {
           "Content-Type": "application/json",
           // Add authorization header if ACCESS_PASSWORD is configured
-          ...(process.env.NEXT_PUBLIC_ACCESS_PASSWORD && {
-            Authorization: `Bearer ${process.env.NEXT_PUBLIC_ACCESS_PASSWORD}`
+          ...(env.NEXT_PUBLIC_ACCESS_PASSWORD && {
+            Authorization: `Bearer ${env.NEXT_PUBLIC_ACCESS_PASSWORD}`
           })
         },
         body: JSON.stringify(requestBody),

--- a/src/components/Setting.tsx
+++ b/src/components/Setting.tsx
@@ -80,18 +80,19 @@ import {
 import { researchStore } from "@/utils/storage";
 import { cn } from "@/utils/style";
 import { omit, capitalize } from "radash";
+import { env } from "@/utils/env";
 
 type SettingProps = {
   open: boolean;
   onClose: () => void;
 };
 
-const BUILD_MODE = process.env.NEXT_PUBLIC_BUILD_MODE;
-const VERSION = process.env.NEXT_PUBLIC_VERSION;
-const DISABLED_AI_PROVIDER = process.env.NEXT_PUBLIC_DISABLED_AI_PROVIDER || "";
+const BUILD_MODE = env.NEXT_PUBLIC_BUILD_MODE;
+const VERSION = env.NEXT_PUBLIC_VERSION;
+const DISABLED_AI_PROVIDER = env.NEXT_PUBLIC_DISABLED_AI_PROVIDER || "";
 const DISABLED_SEARCH_PROVIDER =
-  process.env.NEXT_PUBLIC_DISABLED_SEARCH_PROVIDER || "";
-const MODEL_LIST = process.env.NEXT_PUBLIC_MODEL_LIST || "";
+  env.NEXT_PUBLIC_DISABLED_SEARCH_PROVIDER || "";
+const MODEL_LIST = env.NEXT_PUBLIC_MODEL_LIST || "";
 
 const formSchema = z.object({
   provider: z.string(),

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,30 +2,31 @@ import { NextResponse } from "next/server";
 import { NextRequest } from "next/server";
 import { getCustomModelList, multiApiKeyPolling } from "@/utils/model";
 import { verifySignature } from "@/utils/signature";
+import { env } from "@/utils/env";
 
-const NODE_ENV = process.env.NODE_ENV;
-const accessPassword = process.env.ACCESS_PASSWORD || "";
+const NODE_ENV = env.NODE_ENV;
+const accessPassword = env.ACCESS_PASSWORD || "";
 // AI provider API key
 const GOOGLE_GENERATIVE_AI_API_KEY =
-  process.env.GOOGLE_GENERATIVE_AI_API_KEY || "";
-const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY || "";
-const OPENAI_API_KEY = process.env.OPENAI_API_KEY || "";
-const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY || "";
-const DEEPSEEK_API_KEY = process.env.DEEPSEEK_API_KEY || "";
-const XAI_API_KEY = process.env.XAI_API_KEY || "";
-const MISTRAL_API_KEY = process.env.MISTRAL_API_KEY || "";
-const AZURE_API_KEY = process.env.AZURE_API_KEY || "";
-const OPENAI_COMPATIBLE_API_KEY = process.env.OPENAI_COMPATIBLE_API_KEY || "";
+  env.GOOGLE_GENERATIVE_AI_API_KEY || "";
+const OPENROUTER_API_KEY = env.OPENROUTER_API_KEY || "";
+const OPENAI_API_KEY = env.OPENAI_API_KEY || "";
+const ANTHROPIC_API_KEY = env.ANTHROPIC_API_KEY || "";
+const DEEPSEEK_API_KEY = env.DEEPSEEK_API_KEY || "";
+const XAI_API_KEY = env.XAI_API_KEY || "";
+const MISTRAL_API_KEY = env.MISTRAL_API_KEY || "";
+const AZURE_API_KEY = env.AZURE_API_KEY || "";
+const OPENAI_COMPATIBLE_API_KEY = env.OPENAI_COMPATIBLE_API_KEY || "";
 // Search provider API key
-const TAVILY_API_KEY = process.env.TAVILY_API_KEY || "";
-const FIRECRAWL_API_KEY = process.env.FIRECRAWL_API_KEY || "";
-const EXA_API_KEY = process.env.EXA_API_KEY || "";
-const BOCHA_API_KEY = process.env.BOCHA_API_KEY || "";
+const TAVILY_API_KEY = env.TAVILY_API_KEY || "";
+const FIRECRAWL_API_KEY = env.FIRECRAWL_API_KEY || "";
+const EXA_API_KEY = env.EXA_API_KEY || "";
+const BOCHA_API_KEY = env.BOCHA_API_KEY || "";
 // Disabled Provider
-const DISABLED_AI_PROVIDER = process.env.NEXT_PUBLIC_DISABLED_AI_PROVIDER || "";
+const DISABLED_AI_PROVIDER = env.NEXT_PUBLIC_DISABLED_AI_PROVIDER || "";
 const DISABLED_SEARCH_PROVIDER =
-  process.env.NEXT_PUBLIC_DISABLED_SEARCH_PROVIDER || "";
-const MODEL_LIST = process.env.NEXT_PUBLIC_MODEL_LIST || "";
+  env.NEXT_PUBLIC_DISABLED_SEARCH_PROVIDER || "";
+const MODEL_LIST = env.NEXT_PUBLIC_MODEL_LIST || "";
 
 // Limit the middleware to paths starting with `/api/`
 export const config = {

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+
+const envSchema = z.object({
+  NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
+  HEAD_SCRIPTS: z.string().optional(),
+  ACCESS_PASSWORD: z.string().optional(),
+  NEXT_PUBLIC_ACCESS_PASSWORD: z.string().optional(),
+  NEXT_PUBLIC_BUILD_MODE: z.string().optional(),
+  NEXT_PUBLIC_VERSION: z.string().default("0.0.0"),
+  NEXT_PUBLIC_DISABLED_AI_PROVIDER: z.string().optional(),
+  NEXT_PUBLIC_DISABLED_SEARCH_PROVIDER: z.string().optional(),
+  NEXT_PUBLIC_MODEL_LIST: z.string().optional(),
+  API_PROXY_BASE_URL: z.string().optional(),
+  GOOGLE_GENERATIVE_AI_API_BASE_URL: z
+    .string()
+    .optional(),
+  OPENROUTER_API_BASE_URL: z.string().optional(),
+  OPENAI_API_BASE_URL: z.string().optional(),
+  ANTHROPIC_API_BASE_URL: z.string().optional(),
+  DEEPSEEK_API_BASE_URL: z.string().optional(),
+  XAI_API_BASE_URL: z.string().optional(),
+  MISTRAL_API_BASE_URL: z.string().optional(),
+  AZURE_RESOURCE_NAME: z.string().optional(),
+  AZURE_API_VERSION: z.string().optional(),
+  OPENAI_COMPATIBLE_API_BASE_URL: z.string().optional(),
+  POLLINATIONS_API_BASE_URL: z.string().optional(),
+  OLLAMA_API_BASE_URL: z.string().optional(),
+  TAVILY_API_BASE_URL: z.string().optional(),
+  FIRECRAWL_API_BASE_URL: z.string().optional(),
+  EXA_API_BASE_URL: z.string().optional(),
+  BOCHA_API_BASE_URL: z.string().optional(),
+  SEARXNG_API_BASE_URL: z.string().optional(),
+  GOOGLE_GENERATIVE_AI_API_KEY: z.string().optional(),
+  OPENROUTER_API_KEY: z.string().optional(),
+  OPENAI_API_KEY: z.string().optional(),
+  ANTHROPIC_API_KEY: z.string().optional(),
+  DEEPSEEK_API_KEY: z.string().optional(),
+  XAI_API_KEY: z.string().optional(),
+  MISTRAL_API_KEY: z.string().optional(),
+  AZURE_API_KEY: z.string().optional(),
+  OPENAI_COMPATIBLE_API_KEY: z.string().optional(),
+  TAVILY_API_KEY: z.string().optional(),
+  FIRECRAWL_API_KEY: z.string().optional(),
+  EXA_API_KEY: z.string().optional(),
+  BOCHA_API_KEY: z.string().optional(),
+  MCP_AI_PROVIDER: z.string().optional(),
+  MCP_SEARCH_PROVIDER: z.string().optional(),
+  MCP_THINKING_MODEL: z.string().optional(),
+  MCP_TASK_MODEL: z.string().optional(),
+  REACT_COMPILER: z.string().optional(),
+});
+
+export const env = envSchema.parse(process.env);
+
+export type Env = z.infer<typeof envSchema>;


### PR DESCRIPTION
## Summary
- add zod-based `env` module for validated environment variables
- replace direct `process.env` access across codebase with shared `env`

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7ad402ab8832397dc1af7c18b914d