### PR TITLE
chore: replace gulp workflow with pnpm build

### DIFF
--- a/.github/workflows/npm-gulp.yml
+++ b/.github/workflows/npm-gulp.yml
@@ -1,4 +1,4 @@
-name: NodeJS with Gulp
+name: Node.js Build
 
 on:
   push:
@@ -15,14 +15,18 @@ jobs:
         node-version: [18.x, 20.x, 22.x]
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ matrix.node-version }}
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
 
-    - name: Build
-      run: |
-        npm install
-        gulp
+      - name: Install dependencies
+        run: |
+          corepack enable
+          pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build


### PR DESCRIPTION
## Summary
- replace gulp invocation with pnpm build in CI
- install dependencies with pnpm and enable corepack

## Testing
- `pnpm test` *(fails: Cannot find package '@/utils/logger')*

------
https://chatgpt.com/codex/tasks/task_e_68a7b295af4483238f7b53c5c97fd324