### PR TITLE
chore: fix repository links in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/<org>/deep-equity-research.git"
+    "url": "https://github.com/tdrags/deep-equity-research.git"
   },
-  "bugs": "https://github.com/<org>/deep-equity-research/issues",
+  "bugs": "https://github.com/tdrags/deep-equity-research/issues",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## Summary
- point `repository.url` and `bugs` to the actual GitHub repo

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7b6c4917c83239a0f700050a34592