### PR TITLE
Add standalone and export build scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",
+    "build:standalone": "next build --output standalone",
+    "build:export": "next build && next export",
     "start": "next start",
     "lint": "next lint",
     "test": "vitest run"


### PR DESCRIPTION
## Summary
- add `build:standalone` and `build:export` scripts to package.json

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot find package '@/utils/logger')*


------
https://chatgpt.com/codex/tasks/task_e_68a7b6c7cd808323bc4af1492fdced92