### PR TITLE
docs: document React compiler env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,3 +58,6 @@ NEXT_PUBLIC_DISABLED_AI_PROVIDER=
 NEXT_PUBLIC_DISABLED_SEARCH_PROVIDER=
 NEXT_PUBLIC_MODEL_LIST=
 
+# Enable the experimental React Compiler (set to `true` to opt in)
+REACT_COMPILER=
+

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ pnpm lint
 ```
 
 ## Deployment Tips
-- **Vercel**: configure environment variables in project settings. Optionally enable the experimental React Compiler with `REACT_COMPILER=true`.
+- **Vercel**: configure environment variables in project settings. To opt into the experimental React Compiler, set `REACT_COMPILER=true`.
 - **Docker/Standalone**: build with `pnpm build:standalone` and run the resulting image.
 - **Static Hosting**: generate static export with `pnpm build:export`.
 


### PR DESCRIPTION
## Summary
- document optional REACT_COMPILER flag in example env file
- clarify deployment tip for enabling React Compiler

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7b6c9d5a0832386b46dd0a4db32e6