### PR TITLE
fix: handle missing Azure resource

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -17,7 +17,15 @@ const DEEPSEEK_API_BASE_URL =
 const XAI_API_BASE_URL = process.env.XAI_API_BASE_URL || "https://api.x.ai";
 const MISTRAL_API_BASE_URL =
   process.env.MISTRAL_API_BASE_URL || "https://api.mistral.ai";
-const AZURE_API_BASE_URL = `https://${process.env.AZURE_RESOURCE_NAME}.openai.azure.com/openai/deployments`;
+const AZURE_RESOURCE_NAME = process.env.AZURE_RESOURCE_NAME;
+const AZURE_API_BASE_URL =
+  AZURE_RESOURCE_NAME &&
+  `https://${AZURE_RESOURCE_NAME}.openai.azure.com/openai/deployments`;
+if (!AZURE_API_BASE_URL) {
+  console.warn(
+    "AZURE_RESOURCE_NAME env variable is missing. Azure rewrite will be skipped.",
+  );
+}
 const OPENAI_COMPATIBLE_API_BASE_URL =
   process.env.OPENAI_COMPATIBLE_API_BASE_URL || "";
 const POLLINATIONS_API_BASE_URL =
@@ -80,10 +88,14 @@ export default async function Config(phase: string) {
           source: "/api/ai/mistral/:path*",
           destination: `${MISTRAL_API_BASE_URL}/:path*`,
         },
-        {
-          source: "/api/ai/azure/:path*",
-          destination: `${AZURE_API_BASE_URL}/:path*`,
-        },
+        ...(AZURE_API_BASE_URL
+          ? [
+              {
+                source: "/api/ai/azure/:path*",
+                destination: `${AZURE_API_BASE_URL}/:path*`,
+              },
+            ]
+          : []),
         {
           source: "/api/ai/openaicompatible/:path*",
           destination: `${OPENAI_COMPATIBLE_API_BASE_URL}/:path*`,


### PR DESCRIPTION
## Summary
- verify `AZURE_RESOURCE_NAME` before building Azure API base URL
- conditionally include Azure rewrite and warn when `AZURE_RESOURCE_NAME` is missing

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot find package '@/utils/logger')*


------
https://chatgpt.com/codex/tasks/task_e_68a7b6cb30a083238868470c922d150a