### PR TITLE
Add tests for API and utility modules

### DIFF
--- a/.github/workflows/npm-gulp.yml
+++ b/.github/workflows/npm-gulp.yml
@@ -28,5 +28,8 @@ jobs:
           corepack enable
           pnpm install --frozen-lockfile
 
+      - name: Test
+        run: pnpm test
+
       - name: Build
         run: pnpm build

--- a/tests/api/utils.test.ts
+++ b/tests/api/utils.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import {
+  getAIProviderBaseURL,
+  getSearchProviderBaseURL,
+} from "../../src/app/api/utils";
+
+describe("API provider utils", () => {
+  it("returns base URL for known AI provider", () => {
+    expect(getAIProviderBaseURL("openai")).toBe("https://api.openai.com/v1");
+  });
+
+  it("throws for unknown AI provider", () => {
+    expect(() => getAIProviderBaseURL("unknown")).toThrowError(
+      "Unsupported Provider: unknown",
+    );
+  });
+
+  it("returns base URL for known search provider", () => {
+    expect(getSearchProviderBaseURL("tavily")).toBe("https://api.tavily.com");
+  });
+
+  it("throws for unknown search provider", () => {
+    expect(() => getSearchProviderBaseURL("unknown")).toThrowError(
+      "Unsupported Provider: unknown",
+    );
+  });
+});

--- a/tests/utils/error.test.ts
+++ b/tests/utils/error.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { parseError } from "../../src/utils/error";
+
+describe("parseError", () => {
+  it("returns string errors directly", () => {
+    expect(parseError("my error")).toBe("my error");
+  });
+
+  it("parses API errors with response body", () => {
+    const err = {
+      error: {
+        name: "APIError",
+        message: "ignored",
+        responseBody: JSON.stringify({
+          error: {
+            code: 400,
+            message: "Invalid",
+            status: "INVALID_ARGUMENT",
+          },
+        }),
+      },
+    };
+    expect(parseError(err)).toBe("[INVALID_ARGUMENT]: Invalid");
+  });
+
+  it("parses API errors without response body", () => {
+    const err = {
+      error: {
+        name: "APIError",
+        message: "Something went wrong",
+      },
+    };
+    expect(parseError(err)).toBe("[APIError]: Something went wrong");
+  });
+
+  it("returns default message for unsupported input", () => {
+    expect(parseError(42)).toBe("Unknown Error");
+  });
+});

--- a/tests/utils/text.test.ts
+++ b/tests/utils/text.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import {
+  splitText,
+  removeJsonMarkdown,
+  containsXmlHtmlTags,
+} from "../../src/utils/text";
+
+describe("text utilities", () => {
+  it("splits text into chunks respecting max length", () => {
+    const text = "para1\npara2";
+    const chunks = splitText(text, 10);
+    expect(chunks).toEqual(["para1", "para2"]);
+  });
+
+  it("removes json markdown fences", () => {
+    const input = "```json\n{\"a\":1}\n```";
+    expect(removeJsonMarkdown(input)).toBe('{"a":1}');
+  });
+
+  it("detects xml or html tags", () => {
+    expect(containsXmlHtmlTags("<p>hi</p>")).toBe(true);
+    expect(containsXmlHtmlTags("plain text")).toBe(false);
+  });
+});

--- a/tests/utils/url.test.ts
+++ b/tests/utils/url.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from "vitest";
+import { completePath } from "../../src/utils/url";
+
+describe("completePath", () => {
+  it("appends new path when version missing", () => {
+    expect(completePath("https://api.test.com", "/v1")).toBe(
+      "https://api.test.com/v1",
+    );
+  });
+
+  it("does not append when version exists", () => {
+    expect(completePath("https://api.test.com/v1/", "/v1")).toBe(
+      "https://api.test.com/v1",
+    );
+  });
+
+  it("returns original string for invalid url", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(completePath("not a url", "/v1")).toBe("not a url");
+    spy.mockRestore();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add Vitest config for `@` path alias
- test error parser and text utilities
- verify API provider URL helpers
- run `pnpm test` in CI

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7b6cd21fc8323ae8887b4fcea2f87