### PR TITLE
chore: specify runtime per function

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,8 @@
   "installCommand": "pnpm install",
   "buildCommand": "pnpm build",
   "functions": {
-    "nodeVersion": "18.18.0"
+    "api/**/*.ts": {
+      "runtime": "nodejs18.x"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- configure Vercel to use nodejs18.x runtime for TS API functions

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm dlx vercel deploy --yes --prod` *(fails: No existing credentials found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7bc752ff48323ae340281e050e97e