### PR TITLE
Fix provider key lookup for research modes and handle closed SSE streams

### DIFF
--- a/src/components/ResearchModes/BulkCompanyResearch.tsx
+++ b/src/components/ResearchModes/BulkCompanyResearch.tsx
@@ -51,6 +51,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { logger } from "@/utils/logger";
 import { useSettingStore } from "@/store/setting";
+import { getProviderStateKey } from "@/utils/provider";
 
 // Import MagicDown for rendering markdown
 const MagicDown = dynamic(() => import("@/components/MagicDown"));
@@ -149,12 +150,13 @@ export default function BulkCompanyResearch() {
     try {
       // Get current AI provider and model settings from user configuration
       const currentProvider = settingStore.provider;
-      const thinkingModel = settingStore[`${currentProvider}ThinkingModel` as keyof typeof settingStore] as string;
-      const taskModel = settingStore[`${currentProvider}NetworkingModel` as keyof typeof settingStore] as string;
-      
+      const providerKey = getProviderStateKey(currentProvider);
+      const thinkingModel = settingStore[`${providerKey}ThinkingModel` as keyof typeof settingStore] as string;
+      const taskModel = settingStore[`${providerKey}NetworkingModel` as keyof typeof settingStore] as string;
+
       // Get API keys from user settings
-      const thinkingApiKey = settingStore[`${currentProvider}ApiKey` as keyof typeof settingStore] as string;
-      const taskApiKey = settingStore[`${currentProvider}ApiKey` as keyof typeof settingStore] as string; // Usually same provider
+      const thinkingApiKey = settingStore[`${providerKey}ApiKey` as keyof typeof settingStore] as string;
+      const taskApiKey = settingStore[`${providerKey}ApiKey` as keyof typeof settingStore] as string; // Usually same provider
       const searchApiKey = settingStore[`${settingStore.mode}ApiKey` as keyof typeof settingStore] as string;
 
       // Prepare the request body

--- a/src/components/ResearchModes/CompanyDeepDive.tsx
+++ b/src/components/ResearchModes/CompanyDeepDive.tsx
@@ -19,6 +19,7 @@ import {
 import { downloadFile } from "@/utils/file";
 import { logger } from "@/utils/logger";
 import { useSettingStore } from "@/store/setting";
+import { getProviderStateKey } from "@/utils/provider";
 
 const MagicDown = dynamic(() => import("@/components/MagicDown"));
 
@@ -108,12 +109,13 @@ export default function CompanyDeepDive() {
     try {
       // Get current AI provider and model settings from user configuration
       const currentProvider = settingStore.provider;
-      const thinkingModel = settingStore[`${currentProvider}ThinkingModel` as keyof typeof settingStore] as string;
-      const taskModel = settingStore[`${currentProvider}NetworkingModel` as keyof typeof settingStore] as string;
-      
+      const providerKey = getProviderStateKey(currentProvider);
+      const thinkingModel = settingStore[`${providerKey}ThinkingModel` as keyof typeof settingStore] as string;
+      const taskModel = settingStore[`${providerKey}NetworkingModel` as keyof typeof settingStore] as string;
+
       // Get API keys from user settings
-      const thinkingApiKey = settingStore[`${currentProvider}ApiKey` as keyof typeof settingStore] as string;
-      const taskApiKey = settingStore[`${currentProvider}ApiKey` as keyof typeof settingStore] as string; // Usually same provider
+      const thinkingApiKey = settingStore[`${providerKey}ApiKey` as keyof typeof settingStore] as string;
+      const taskApiKey = settingStore[`${providerKey}ApiKey` as keyof typeof settingStore] as string; // Usually same provider
       const searchApiKey = settingStore[`${settingStore.mode}ApiKey` as keyof typeof settingStore] as string;
 
       // Prepare the request body with all company information and user's AI settings

--- a/src/components/ResearchModes/MarketResearch.tsx
+++ b/src/components/ResearchModes/MarketResearch.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSettingStore } from "@/store/setting";
+import { getProviderStateKey } from "@/utils/provider";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { TrendingUp, Search, Loader2, BarChart, PieChart, LineChart, Download, FileText, Signature } from "lucide-react";
@@ -67,14 +68,15 @@ export default function MarketResearch() {
     try {
       // Get current AI provider and model settings from user configuration
       const currentProvider = settingStore.provider;
-      const thinkingModel = settingStore[`${currentProvider}ThinkingModel` as keyof typeof settingStore] as string;
-      const taskModel = settingStore[`${currentProvider}NetworkingModel` as keyof typeof settingStore] as string;
+      const providerKey = getProviderStateKey(currentProvider);
+      const thinkingModel = settingStore[`${providerKey}ThinkingModel` as keyof typeof settingStore] as string;
+      const taskModel = settingStore[`${providerKey}NetworkingModel` as keyof typeof settingStore] as string;
 
       // Create market research query with context
       const marketQuery = `${marketTopic}${specificQuestions ? `\n\nSpecific focus areas: ${specificQuestions}` : ''}`;
 
       // Get API keys from user settings
-      const aiApiKey = settingStore[`${currentProvider}ApiKey` as keyof typeof settingStore] as string;
+      const aiApiKey = settingStore[`${providerKey}ApiKey` as keyof typeof settingStore] as string;
       const searchApiKey = settingStore[`${settingStore.mode}ApiKey` as keyof typeof settingStore] as string;
 
       const requestBody = {

--- a/src/utils/deep-research/provider.ts
+++ b/src/utils/deep-research/provider.ts
@@ -197,31 +197,31 @@ export async function createAIProvider({
         // web_search_preview at call time if needed.
         const responsesModel = openai.responses(model);
 
-        if (modelRequiresTools(provider, model)) {
-          const requiredTool = openai.tools.webSearchPreview({
-            searchContextSize: "medium",
-          });
+          if (modelRequiresTools(provider, model)) {
+            const requiredTool = openai.tools.webSearchPreview({
+              searchContextSize: "medium",
+            }) as any;
 
-          const baseGenerate = responsesModel.doGenerate.bind(responsesModel);
-          const baseStream = responsesModel.doStream.bind(responsesModel);
+            const baseGenerate = responsesModel.doGenerate.bind(responsesModel);
+            const baseStream = responsesModel.doStream.bind(responsesModel);
 
           return {
             ...responsesModel,
             async doGenerate(options) {
               const mode = options.mode;
-              if (mode?.type === "regular") {
-                const tools = [...(mode.tools || []), requiredTool];
-                return baseGenerate({ ...options, mode: { ...mode, tools } });
-              }
-              return baseGenerate(options);
+                if (mode?.type === "regular") {
+                  const tools = [...(mode.tools || []), requiredTool] as any;
+                  return baseGenerate({ ...options, mode: { ...mode, tools } });
+                }
+                return baseGenerate(options);
             },
             async doStream(options) {
               const mode = options.mode;
-              if (mode?.type === "regular") {
-                const tools = [...(mode.tools || []), requiredTool];
-                return baseStream({ ...options, mode: { ...mode, tools } });
-              }
-              return baseStream(options);
+                if (mode?.type === "regular") {
+                  const tools = [...(mode.tools || []), requiredTool] as any;
+                  return baseStream({ ...options, mode: { ...mode, tools } });
+                }
+                return baseStream(options);
             },
           } as typeof responsesModel;
         }

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -1,0 +1,10 @@
+export function getProviderStateKey(provider: string): string {
+  const specialCases: Record<string, string> = {
+    openai: "openAI",
+    openrouter: "openRouter",
+    openaicompatible: "openAICompatible",
+    xai: "xAI",
+  };
+  return specialCases[provider] || provider;
+}
+

--- a/tests/utils/provider.test.ts
+++ b/tests/utils/provider.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { getProviderStateKey } from "@/utils/provider";
+
+describe("getProviderStateKey", () => {
+  it("maps special providers to state keys", () => {
+    expect(getProviderStateKey("openai")).toBe("openAI");
+    expect(getProviderStateKey("openrouter")).toBe("openRouter");
+    expect(getProviderStateKey("openaicompatible")).toBe("openAICompatible");
+    expect(getProviderStateKey("xai")).toBe("xAI");
+  });
+
+  it("returns provider unchanged when mapping not needed", () => {
+    expect(getProviderStateKey("anthropic")).toBe("anthropic");
+    expect(getProviderStateKey("deepseek")).toBe("deepseek");
+  });
+});
+

--- a/tests/utils/sse.test.ts
+++ b/tests/utils/sse.test.ts
@@ -44,8 +44,9 @@ describe("createSSEStream", () => {
     const final = await reader.read();
     expect(final.done).toBe(true);
 
-    // further events should not be delivered
-    sendEvent("after", { test: true });
+    // further events should not be delivered and sendEvent should indicate failure
+    const sent = sendEvent("after", { test: true });
+    expect(sent).toBe(false);
     const after = await reader.read();
     expect(after.done).toBe(true);
   });


### PR DESCRIPTION
## Summary
- handle events sent after SSE stream closes by returning false instead of warning
- assert returned value in SSE stream test
- fix OpenAI responses wrapper to cast web_search_preview tool for build compatibility
- map provider IDs to setting store keys so API keys/models resolve correctly in research modes
- test provider key mapping utility

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af2fd977ec832381e9f5e1c2f3e9e0