### PR TITLE
Fix provider key lookup for research modes and handle closed SSE streams

### DIFF
--- a/src/components/ResearchModes/BulkCompanyResearch.tsx
+++ b/src/components/ResearchModes/BulkCompanyResearch.tsx
@@ -51,6 +51,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { logger } from "@/utils/logger";
 import { useSettingStore } from "@/store/setting";
+import { getProviderStateKey, getProviderApiKey } from "@/utils/provider";
 
 // Import MagicDown for rendering markdown
 const MagicDown = dynamic(() => import("@/components/MagicDown"));
@@ -148,14 +149,20 @@ export default function BulkCompanyResearch() {
     
     try {
       // Get current AI provider and model settings from user configuration
-      const currentProvider = settingStore.provider;
-      const thinkingModel = settingStore[`${currentProvider}ThinkingModel` as keyof typeof settingStore] as string;
-      const taskModel = settingStore[`${currentProvider}NetworkingModel` as keyof typeof settingStore] as string;
-      
+      const currentProvider = settingStore.provider || "openai";
+      const providerKey = getProviderStateKey(currentProvider);
+      const thinkingModel = settingStore[
+        `${providerKey}ThinkingModel` as keyof typeof settingStore
+      ] as string;
+      const taskModel = settingStore[
+        `${providerKey}NetworkingModel` as keyof typeof settingStore
+      ] as string;
+
       // Get API keys from user settings
-      const thinkingApiKey = settingStore[`${currentProvider}ApiKey` as keyof typeof settingStore] as string;
-      const taskApiKey = settingStore[`${currentProvider}ApiKey` as keyof typeof settingStore] as string; // Usually same provider
-      const searchApiKey = settingStore[`${settingStore.mode}ApiKey` as keyof typeof settingStore] as string;
+      const thinkingApiKey = getProviderApiKey(settingStore, currentProvider);
+      const taskApiKey = getProviderApiKey(settingStore, currentProvider); // Usually same provider
+      const searchProvider = settingStore.searchProvider || "model";
+      const searchApiKey = getProviderApiKey(settingStore, searchProvider);
 
       // Prepare the request body
       const requestBody = {
@@ -173,7 +180,7 @@ export default function BulkCompanyResearch() {
         taskApiKey: taskApiKey,
         
         // Pass search provider if configured
-        searchProviderId: settingStore.mode,
+        searchProviderId: searchProvider,
         searchApiKey: searchApiKey,
       };
       

--- a/src/components/ResearchModes/CompanyDeepDive.tsx
+++ b/src/components/ResearchModes/CompanyDeepDive.tsx
@@ -19,6 +19,7 @@ import {
 import { downloadFile } from "@/utils/file";
 import { logger } from "@/utils/logger";
 import { useSettingStore } from "@/store/setting";
+import { getProviderStateKey, getProviderApiKey } from "@/utils/provider";
 
 const MagicDown = dynamic(() => import("@/components/MagicDown"));
 
@@ -107,14 +108,20 @@ export default function CompanyDeepDive() {
     
     try {
       // Get current AI provider and model settings from user configuration
-      const currentProvider = settingStore.provider;
-      const thinkingModel = settingStore[`${currentProvider}ThinkingModel` as keyof typeof settingStore] as string;
-      const taskModel = settingStore[`${currentProvider}NetworkingModel` as keyof typeof settingStore] as string;
-      
+      const currentProvider = settingStore.provider || "openai";
+      const providerKey = getProviderStateKey(currentProvider);
+      const thinkingModel = settingStore[
+        `${providerKey}ThinkingModel` as keyof typeof settingStore
+      ] as string;
+      const taskModel = settingStore[
+        `${providerKey}NetworkingModel` as keyof typeof settingStore
+      ] as string;
+
       // Get API keys from user settings
-      const thinkingApiKey = settingStore[`${currentProvider}ApiKey` as keyof typeof settingStore] as string;
-      const taskApiKey = settingStore[`${currentProvider}ApiKey` as keyof typeof settingStore] as string; // Usually same provider
-      const searchApiKey = settingStore[`${settingStore.mode}ApiKey` as keyof typeof settingStore] as string;
+      const thinkingApiKey = getProviderApiKey(settingStore, currentProvider);
+      const taskApiKey = getProviderApiKey(settingStore, currentProvider); // Usually same provider
+      const searchProvider = settingStore.searchProvider || "model";
+      const searchApiKey = getProviderApiKey(settingStore, searchProvider);
 
       // Prepare the request body with all company information and user's AI settings
       const requestBody = {
@@ -131,7 +138,7 @@ export default function CompanyDeepDive() {
         // Pass user's configured AI models
         thinkingProviderId: currentProvider,
         thinkingModelId: thinkingModel,
-        taskProviderId: currentProvider, 
+        taskProviderId: currentProvider,
         taskModelId: taskModel,
         
         // Pass user's API keys and reasoning effort
@@ -141,7 +148,7 @@ export default function CompanyDeepDive() {
         taskReasoningEffort: settingStore.openAIReasoningEffort,
         
         // Pass search provider if configured
-        searchProviderId: settingStore.mode,
+        searchProviderId: searchProvider,
         searchApiKey: searchApiKey,
       };
       

--- a/src/components/ResearchModes/MarketResearch.tsx
+++ b/src/components/ResearchModes/MarketResearch.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSettingStore } from "@/store/setting";
+import { getProviderStateKey, getProviderApiKey } from "@/utils/provider";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { TrendingUp, Search, Loader2, BarChart, PieChart, LineChart, Download, FileText, Signature } from "lucide-react";
@@ -66,23 +67,29 @@ export default function MarketResearch() {
 
     try {
       // Get current AI provider and model settings from user configuration
-      const currentProvider = settingStore.provider;
-      const thinkingModel = settingStore[`${currentProvider}ThinkingModel` as keyof typeof settingStore] as string;
-      const taskModel = settingStore[`${currentProvider}NetworkingModel` as keyof typeof settingStore] as string;
+      const currentProvider = settingStore.provider || "openai";
+      const providerKey = getProviderStateKey(currentProvider);
+      const thinkingModel = settingStore[
+        `${providerKey}ThinkingModel` as keyof typeof settingStore
+      ] as string;
+      const taskModel = settingStore[
+        `${providerKey}NetworkingModel` as keyof typeof settingStore
+      ] as string;
 
       // Create market research query with context
       const marketQuery = `${marketTopic}${specificQuestions ? `\n\nSpecific focus areas: ${specificQuestions}` : ''}`;
 
       // Get API keys from user settings
-      const aiApiKey = settingStore[`${currentProvider}ApiKey` as keyof typeof settingStore] as string;
-      const searchApiKey = settingStore[`${settingStore.mode}ApiKey` as keyof typeof settingStore] as string;
+      const aiApiKey = getProviderApiKey(settingStore, currentProvider);
+      const searchProvider = settingStore.searchProvider || "model";
+      const searchApiKey = getProviderApiKey(settingStore, searchProvider);
 
       const requestBody = {
         query: marketQuery,
         provider: currentProvider,
         thinkingModel: thinkingModel,
         taskModel: taskModel,
-        searchProvider: settingStore.mode,
+        searchProvider: searchProvider,
         language: "en-US",
         maxResult: 10,
         enableCitationImage: true,

--- a/src/utils/deep-research/provider.ts
+++ b/src/utils/deep-research/provider.ts
@@ -197,31 +197,31 @@ export async function createAIProvider({
         // web_search_preview at call time if needed.
         const responsesModel = openai.responses(model);
 
-        if (modelRequiresTools(provider, model)) {
-          const requiredTool = openai.tools.webSearchPreview({
-            searchContextSize: "medium",
-          });
+          if (modelRequiresTools(provider, model)) {
+            const requiredTool = openai.tools.webSearchPreview({
+              searchContextSize: "medium",
+            }) as any;
 
-          const baseGenerate = responsesModel.doGenerate.bind(responsesModel);
-          const baseStream = responsesModel.doStream.bind(responsesModel);
+            const baseGenerate = responsesModel.doGenerate.bind(responsesModel);
+            const baseStream = responsesModel.doStream.bind(responsesModel);
 
           return {
             ...responsesModel,
             async doGenerate(options) {
               const mode = options.mode;
-              if (mode?.type === "regular") {
-                const tools = [...(mode.tools || []), requiredTool];
-                return baseGenerate({ ...options, mode: { ...mode, tools } });
-              }
-              return baseGenerate(options);
+                if (mode?.type === "regular") {
+                  const tools = [...(mode.tools || []), requiredTool] as any;
+                  return baseGenerate({ ...options, mode: { ...mode, tools } });
+                }
+                return baseGenerate(options);
             },
             async doStream(options) {
               const mode = options.mode;
-              if (mode?.type === "regular") {
-                const tools = [...(mode.tools || []), requiredTool];
-                return baseStream({ ...options, mode: { ...mode, tools } });
-              }
-              return baseStream(options);
+                if (mode?.type === "regular") {
+                  const tools = [...(mode.tools || []), requiredTool] as any;
+                  return baseStream({ ...options, mode: { ...mode, tools } });
+                }
+                return baseStream(options);
             },
           } as typeof responsesModel;
         }

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -1,0 +1,22 @@
+export function getProviderStateKey(provider: string): string {
+  const specialCases: Record<string, string> = {
+    openai: "openAI",
+    openrouter: "openRouter",
+    openaicompatible: "openAICompatible",
+    xai: "xAI",
+  };
+  return specialCases[provider] || provider;
+}
+
+/**
+ * Lookup a provider's API key from the settings store using a provider id.
+ * Falls back to the generic `apiKey` field if a provider-specific key is not found.
+ */
+export function getProviderApiKey(
+  store: Record<string, any>,
+  provider: string,
+): string {
+  const keyName = `${getProviderStateKey(provider)}ApiKey`;
+  return store[keyName] || store.apiKey || "";
+}
+

--- a/tests/utils/provider.test.ts
+++ b/tests/utils/provider.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { getProviderStateKey, getProviderApiKey } from "@/utils/provider";
+
+describe("getProviderStateKey", () => {
+  it("maps special providers to state keys", () => {
+    expect(getProviderStateKey("openai")).toBe("openAI");
+    expect(getProviderStateKey("openrouter")).toBe("openRouter");
+    expect(getProviderStateKey("openaicompatible")).toBe("openAICompatible");
+    expect(getProviderStateKey("xai")).toBe("xAI");
+  });
+
+  it("returns provider unchanged when mapping not needed", () => {
+    expect(getProviderStateKey("anthropic")).toBe("anthropic");
+    expect(getProviderStateKey("deepseek")).toBe("deepseek");
+  });
+});
+
+describe("getProviderApiKey", () => {
+  const store = {
+    apiKey: "generic-key",
+    openAIApiKey: "openai-key",
+    tavilyApiKey: "tavily-key",
+  };
+
+  it("prefers provider specific keys", () => {
+    expect(getProviderApiKey(store, "openai")).toBe("openai-key");
+  });
+
+  it("falls back to generic key if provider specific key missing", () => {
+    expect(getProviderApiKey(store, "anthropic")).toBe("generic-key");
+  });
+
+  it("works with search providers", () => {
+    expect(getProviderApiKey(store, "tavily")).toBe("tavily-key");
+  });
+});
+

--- a/tests/utils/sse.test.ts
+++ b/tests/utils/sse.test.ts
@@ -44,8 +44,9 @@ describe("createSSEStream", () => {
     const final = await reader.read();
     expect(final.done).toBe(true);
 
-    // further events should not be delivered
-    sendEvent("after", { test: true });
+    // further events should not be delivered and sendEvent should indicate failure
+    const sent = sendEvent("after", { test: true });
+    expect(sent).toBe(false);
     const after = await reader.read();
     expect(after.done).toBe(true);
   });


### PR DESCRIPTION
## Summary
- normalize provider IDs and pull API keys via shared helper
- default research components to configured search provider and send associated keys
- test provider API key lookup

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af2fd977ec832381e9f5e1c2f3e9e0