### PR TITLE
Add one-page PDF app summary and generator script

### DIFF
--- a/docs/deep-equity-research-one-page-summary.md
+++ b/docs/deep-equity-research-one-page-summary.md
@@ -1,0 +1,33 @@
+# Deep Equity Research — One-Page App Summary
+
+## What it is
+- TJ Deep Research is a Next.js app that orchestrates AI reasoning/task models with web search to produce equity research reports quickly.
+- The app is designed to run research workflows in the browser, with user-provided API keys configured in Settings.
+
+## Who it's for
+- Primary persona: equity researchers, investors, and analysts who need fast, structured company and market intelligence.
+
+## What it does
+- Offers 8 research modes: Company Deep Dive, Bulk Company Research, Market Research, Free Form, Company Discovery, Case Studies, Doc Storage, and Prompt Library.
+- Supports multiple AI providers (OpenAI, Anthropic, Google, OpenRouter, DeepSeek, Ollama, and others).
+- Supports multiple search providers including Tavily, Exa, Firecrawl, model-native search, and SearXNG.
+- Streams long-running deep-research progress/results via Server-Sent Events (SSE).
+- Persists app settings/history state in browser storage using Zustand; sensitive settings fields are encrypted before localStorage persistence.
+- Includes history/knowledge side panels and prompt libraries for repeatable workflows.
+
+## How it works (repo-evidenced architecture)
+- UI layer: Next.js App Router page dynamically loads research mode components and side panels (Settings, History, Knowledge).
+- State layer: Zustand stores manage global UI state, settings, tasks, history, and knowledge.
+- Orchestration layer: `useDeepResearch` coordinates model calls, question/plan generation, web search, and report assembly with streaming AI SDK responses.
+- API layer: `/api/sse` validates keys, configures provider/search endpoints, creates a `DeepResearch` engine instance, and streams events back to the client.
+- Integration layer: dedicated API proxy routes exist for AI and search providers under `/api/ai/*` and `/api/search/*`.
+
+## How to run (minimal getting started)
+1. Install deps: `pnpm install`
+2. Start dev server: `pnpm dev`
+3. Open `http://localhost:3000`
+4. In Settings, enter AI provider key and search provider key.
+5. Choose a research mode and run a query.
+
+## Not found in repo
+- Formal SLA/performance targets and canonical production architecture diagram: **Not found in repo**.

--- a/docs/deep-equity-research-one-page-summary.pdf
+++ b/docs/deep-equity-research-one-page-summary.pdf
@@ -1,0 +1,74 @@
+%PDF-1.4
+% ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 612 792 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260312054052+00'00') /Creator (anonymous) /Keywords () /ModDate (D:20260312054052+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (unspecified) /Title (Deep Equity Research - One Page Summary) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1846
+>>
+stream
+Gat=+gN)%,&:Ml+ls&M/X:'0YqrG\=i[.A^OZMlOquTfYKEq]_!0XFumobaH75nde:E3YJEk-PBfsBucFn)XO?djttm>O*X4mF=M>>T7b*mj6e?-Q]po7VFbG^e4=*m]1ELg_*$NsE?VY0#o#V3EuGrNf@0:LBrb_PJco99M#X1%Os;/1"T_3DDG8-J\TRB&@:qL-rBs<;_,ls2pR''98O/E5_4a2bhaNX'U,ioBPA=s2h=r0D#$],m#OnpnMICb3m8'h^`Sr+JZ8\)<@qZ*n0I7MFCRr.8POZbD4IDL/03Mn?XZp-%0_V85C$\jJ;:r.'r7CiRa=I\^[3o.]d;2n#;6\/EP1&2lWmV=\i]n/e]Fl"k;t%N0Cep_%VjX[GJB^_Mn?!\lLRuO)jC2X/1r":<.4qA+Z=7l\2c/:Wf>(8bW^%Uh^^!D"-s/q/=e'2db@scs#j#V:I3IEoV,99N+9qDH5:fL&eH*q^Gf8`VZU+<4lG^rem\.FjF\AP!;:segV@djjJ]PEW-Z"*4Jc'(:7<F.*N\2L#..fZ9og*!eQ-qTg_et-4LQNe7Q6Fqfk-\Y@VCaW&q"5;C4r:eP_i8^'ppuAFcN\k#O[\6\aX[0hu'k$U@"A8):E'rAhPA.ujLKWOB*$D`;uJSKD%87DD>4NXi4_P]UbJeiI'l!7GhN<$5HrTA$DhHe^$^UhSK*Pls182T6Ku?qCN%[gmrkI8]eL/2q^sE%j;TGIknSVTUkYW*E!`pTb6Y_qjW3\MP*]/\3WEj_V*J(;72#WUXBqeQ9?hgd;Ln<6@'n[2,/Yd^"FXFa)9$:k-i^:s$Ub;TbdR5aWkB`)^TFF7k%g?7RC%-[*($37Oo>!Beb\##8ihc[U@lhj@2;Zcm-6qdlA+29So8$JQ[s7cpV66BKk5?[N)38D;Nn#s?=\\^RN7JZcG+AMC%2Wuljh[7J]Q-s(BnZFTeZ<]VbM9tEh:_P#T,8gbij8-3,;8cHE>"_R`aDDY[b:_Y'dTqn8)XD@Cl_--fcX%hmQGsKR19A#@0*i[M_#,A4AWUDZb4lEj48N2c%N0poDcJ$pAQ?*3$@%,Fk4D1%j][4-JqF1js-1\^1,)CSZUb_\2H-'H9fE"1g*ErijA&<I9SP%HR8qS@?DA?\=^Uo\BHd/5?H[jh4(45;kWsR#97F=s\*\bh47UuiklTG4a@'!s5d=/3SiaS.4;1mLnZ<L%^oS41#*srceo^P16ZW7<&YML\/`j278HVoo5/&Nc$3D45XL$#tAFBb"O>JuF'hH#COpuY0YNELAD2?0g[(M1i7)pEL!VeYNhX`a,o\DBWS+GL_os(?t2EFUBJ_@VHc/-<5>p7.LS6ULaX5m:u-d?*j(B(t4;DAk]"$?mo"G'`tH3<b=I4r&!!m%e5d]V(M>F[WAnGQM`9<qBE-Y:crth8NIXfdRMpAtE5N@(m!$n3)A<(eM&5VTBkTU[c_gB=cQ4)#;T8ARTr[,$jdu`]I8%(![``*;8\>&`g7C-MB7&6n#N$<;(i"L78BCI"6[?2ZVR!b1#%K0mG2k'<:Zd7pHNF\%2Y'(pEPnAN&"5Os?GF(Y$(KciTLh%DB_ui9"u,mf`pEn(%oUGBX)g&Pd,7Q=Gip9qE)9C#)U0E`QD%'#^2Y;M_U^VEEPS=?'uO1T=MF+)uO>TN)9nH)D<gaNF?uhX>X"9lWY1-6L1;W]drtZ*Ip^D(aTEh\-!^2lSI0X)Ee!]j"Wtjq:IkQ\.)BJkb8i/([Q(,,sr'ZXqrZSNP6O2P/0A;Mcp$cMJqF2>qXE_/s#Q2`)q1ej3oe\4D=i?Zi$7r4=O=g$sln\IrSi$j5d/HH5^,X+(/]9ncX~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000061 00000 n 
+0000000102 00000 n 
+0000000209 00000 n 
+0000000321 00000 n 
+0000000514 00000 n 
+0000000582 00000 n 
+0000000874 00000 n 
+0000000933 00000 n 
+trailer
+<<
+/ID 
+[<625c0887b78b49a445965d0f940c4e34><625c0887b78b49a445965d0f940c4e34>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+2870
+%%EOF

--- a/scripts/generate_one_page_summary_pdf.py
+++ b/scripts/generate_one_page_summary_pdf.py
@@ -1,0 +1,100 @@
+from reportlab.lib import colors
+from reportlab.lib.pagesizes import letter
+from reportlab.lib.units import inch
+from reportlab.pdfgen import canvas
+from textwrap import wrap
+
+OUTPUT_PATH = 'docs/deep-equity-research-one-page-summary.pdf'
+
+SECTIONS = [
+    (
+        'What it is',
+        [
+            'TJ Deep Research is a Next.js app that orchestrates AI reasoning/task models with web search to produce equity research reports quickly.',
+            'The app is designed to run research workflows in the browser, with user-provided API keys configured in Settings.',
+        ],
+    ),
+    (
+        "Who it's for",
+        [
+            'Primary persona: equity researchers, investors, and analysts who need fast, structured company and market intelligence.',
+        ],
+    ),
+    (
+        'What it does',
+        [
+            'Offers 8 research modes: Company Deep Dive, Bulk Company Research, Market Research, Free Form, Company Discovery, Case Studies, Doc Storage, and Prompt Library.',
+            'Supports multiple AI providers (OpenAI, Anthropic, Google, OpenRouter, DeepSeek, Ollama, and others).',
+            'Supports multiple search providers including Tavily, Exa, Firecrawl, model-native search, and SearXNG.',
+            'Streams long-running deep-research progress/results via Server-Sent Events (SSE).',
+            'Persists app settings/history state in browser storage using Zustand; sensitive settings fields are encrypted before localStorage persistence.',
+            'Includes history/knowledge side panels and prompt libraries for repeatable workflows.',
+        ],
+    ),
+    (
+        'How it works (repo-evidenced architecture)',
+        [
+            'UI layer: Next.js App Router page dynamically loads research mode components and side panels (Settings, History, Knowledge).',
+            'State layer: Zustand stores manage global UI state, settings, tasks, history, and knowledge.',
+            'Orchestration layer: useDeepResearch coordinates model calls, question/plan generation, web search, and report assembly with streaming AI SDK responses.',
+            'API layer: /api/sse validates keys, configures provider/search endpoints, creates a DeepResearch engine instance, and streams events back to the client.',
+            'Integration layer: dedicated API proxy routes exist for AI and search providers under /api/ai/* and /api/search/*.',
+        ],
+    ),
+    (
+        'How to run (minimal getting started)',
+        [
+            '1) Install deps: pnpm install',
+            '2) Start dev server: pnpm dev',
+            '3) Open http://localhost:3000',
+            '4) In Settings, enter AI provider key and search provider key.',
+            '5) Choose a research mode and run a query.',
+        ],
+    ),
+    (
+        'Not found in repo',
+        [
+            'Formal SLA/performance targets and canonical production architecture diagram: Not found in repo.',
+        ],
+    ),
+]
+
+
+def build_pdf() -> None:
+    c = canvas.Canvas(OUTPUT_PATH, pagesize=letter)
+    width, height = letter
+
+    x = 0.7 * inch
+    y = height - 0.7 * inch
+    line_height = 13
+
+    c.setTitle('Deep Equity Research - One Page Summary')
+    c.setFont('Helvetica-Bold', 16)
+    c.drawString(x, y, 'Deep Equity Research — One-Page App Summary')
+    y -= 20
+
+    c.setStrokeColor(colors.HexColor('#cccccc'))
+    c.line(x, y, width - 0.7 * inch, y)
+    y -= 18
+
+    for section_title, bullets in SECTIONS:
+        c.setFont('Helvetica-Bold', 11.5)
+        c.drawString(x, y, section_title)
+        y -= line_height
+
+        c.setFont('Helvetica', 10)
+        for bullet in bullets:
+            for idx, segment in enumerate(wrap(bullet, 108)):
+                prefix = '• ' if idx == 0 else '  '
+                c.drawString(x + 8, y, f'{prefix}{segment}')
+                y -= line_height
+            y -= 1
+
+        y -= 4
+
+    c.showPage()
+    c.save()
+
+
+if __name__ == '__main__':
+    build_pdf()


### PR DESCRIPTION
### Motivation
- Provide a concise, single-page summary of the Deep Equity Research app suitable for stakeholders and documentation distribution.
- Make the summary reproducible and maintainable by including a source markdown file and a deterministic generator script. 

### Description
- Add `docs/deep-equity-research-one-page-summary.md` containing structured content: what it is, who it’s for, key features, repo-evidenced architecture, minimal run steps, and a "Not found in repo" note.
- Add `scripts/generate_one_page_summary_pdf.py`, a ReportLab-based script that renders the summary into a single-letter-page PDF with controlled wrapping and layout.
- Add generated deliverable `docs/deep-equity-research-one-page-summary.pdf` so the one-page summary is available immediately in the repository.
- The generator script is deterministic and designed to keep output to a single page by wrapping text and using fixed layout metrics. 

### Testing
- Ran the generator with `python scripts/generate_one_page_summary_pdf.py` and the script completed successfully without errors.
- Installed validation dependencies (`reportlab`, `pypdf`) via `python -m pip install` which completed successfully during validation.
- Verified the generated PDF contains exactly one page using `from pypdf import PdfReader` which reported `pages: 1`.
- No project unit or integration tests were modified or required for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2514fd9588323b5d46aa0449f7b67)