### PR TITLE
Add AI proxy handlers, normalize streaming fields, and switch to `maxOutputTokens` for providers

### DIFF
--- a/docs/deep-equity-research-one-page-summary.pdf
+++ b/docs/deep-equity-research-one-page-summary.pdf
@@ -1,0 +1,74 @@
+%PDF-1.4
+% ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 612 792 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260312054052+00'00') /Creator (anonymous) /Keywords () /ModDate (D:20260312054052+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (unspecified) /Title (Deep Equity Research - One Page Summary) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1846
+>>
+stream
+Gat=+gN)%,&:Ml+ls&M/X:'0YqrG\=i[.A^OZMlOquTfYKEq]_!0XFumobaH75nde:E3YJEk-PBfsBucFn)XO?djttm>O*X4mF=M>>T7b*mj6e?-Q]po7VFbG^e4=*m]1ELg_*$NsE?VY0#o#V3EuGrNf@0:LBrb_PJco99M#X1%Os;/1"T_3DDG8-J\TRB&@:qL-rBs<;_,ls2pR''98O/E5_4a2bhaNX'U,ioBPA=s2h=r0D#$],m#OnpnMICb3m8'h^`Sr+JZ8\)<@qZ*n0I7MFCRr.8POZbD4IDL/03Mn?XZp-%0_V85C$\jJ;:r.'r7CiRa=I\^[3o.]d;2n#;6\/EP1&2lWmV=\i]n/e]Fl"k;t%N0Cep_%VjX[GJB^_Mn?!\lLRuO)jC2X/1r":<.4qA+Z=7l\2c/:Wf>(8bW^%Uh^^!D"-s/q/=e'2db@scs#j#V:I3IEoV,99N+9qDH5:fL&eH*q^Gf8`VZU+<4lG^rem\.FjF\AP!;:segV@djjJ]PEW-Z"*4Jc'(:7<F.*N\2L#..fZ9og*!eQ-qTg_et-4LQNe7Q6Fqfk-\Y@VCaW&q"5;C4r:eP_i8^'ppuAFcN\k#O[\6\aX[0hu'k$U@"A8):E'rAhPA.ujLKWOB*$D`;uJSKD%87DD>4NXi4_P]UbJeiI'l!7GhN<$5HrTA$DhHe^$^UhSK*Pls182T6Ku?qCN%[gmrkI8]eL/2q^sE%j;TGIknSVTUkYW*E!`pTb6Y_qjW3\MP*]/\3WEj_V*J(;72#WUXBqeQ9?hgd;Ln<6@'n[2,/Yd^"FXFa)9$:k-i^:s$Ub;TbdR5aWkB`)^TFF7k%g?7RC%-[*($37Oo>!Beb\##8ihc[U@lhj@2;Zcm-6qdlA+29So8$JQ[s7cpV66BKk5?[N)38D;Nn#s?=\\^RN7JZcG+AMC%2Wuljh[7J]Q-s(BnZFTeZ<]VbM9tEh:_P#T,8gbij8-3,;8cHE>"_R`aDDY[b:_Y'dTqn8)XD@Cl_--fcX%hmQGsKR19A#@0*i[M_#,A4AWUDZb4lEj48N2c%N0poDcJ$pAQ?*3$@%,Fk4D1%j][4-JqF1js-1\^1,)CSZUb_\2H-'H9fE"1g*ErijA&<I9SP%HR8qS@?DA?\=^Uo\BHd/5?H[jh4(45;kWsR#97F=s\*\bh47UuiklTG4a@'!s5d=/3SiaS.4;1mLnZ<L%^oS41#*srceo^P16ZW7<&YML\/`j278HVoo5/&Nc$3D45XL$#tAFBb"O>JuF'hH#COpuY0YNELAD2?0g[(M1i7)pEL!VeYNhX`a,o\DBWS+GL_os(?t2EFUBJ_@VHc/-<5>p7.LS6ULaX5m:u-d?*j(B(t4;DAk]"$?mo"G'`tH3<b=I4r&!!m%e5d]V(M>F[WAnGQM`9<qBE-Y:crth8NIXfdRMpAtE5N@(m!$n3)A<(eM&5VTBkTU[c_gB=cQ4)#;T8ARTr[,$jdu`]I8%(![``*;8\>&`g7C-MB7&6n#N$<;(i"L78BCI"6[?2ZVR!b1#%K0mG2k'<:Zd7pHNF\%2Y'(pEPnAN&"5Os?GF(Y$(KciTLh%DB_ui9"u,mf`pEn(%oUGBX)g&Pd,7Q=Gip9qE)9C#)U0E`QD%'#^2Y;M_U^VEEPS=?'uO1T=MF+)uO>TN)9nH)D<gaNF?uhX>X"9lWY1-6L1;W]drtZ*Ip^D(aTEh\-!^2lSI0X)Ee!]j"Wtjq:IkQ\.)BJkb8i/([Q(,,sr'ZXqrZSNP6O2P/0A;Mcp$cMJqF2>qXE_/s#Q2`)q1ej3oe\4D=i?Zi$7r4=O=g$sln\IrSi$j5d/HH5^,X+(/]9ncX~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000061 00000 n 
+0000000102 00000 n 
+0000000209 00000 n 
+0000000321 00000 n 
+0000000514 00000 n 
+0000000582 00000 n 
+0000000874 00000 n 
+0000000933 00000 n 
+trailer
+<<
+/ID 
+[<625c0887b78b49a445965d0f940c4e34><625c0887b78b49a445965d0f940c4e34>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+2870
+%%EOF

--- a/src/app/api/ai/deepseek/[...slug]/proxy-handler.ts
+++ b/src/app/api/ai/deepseek/[...slug]/proxy-handler.ts
@@ -1,0 +1,6 @@
+import { DEEPSEEK_BASE_URL } from '@/constants/urls';
+import { createProxyHandler } from '../../create-proxy-handler';
+
+const API_PROXY_BASE_URL = process.env.DEEPSEEK_API_BASE_URL || DEEPSEEK_BASE_URL;
+
+export const proxyHandler = createProxyHandler(API_PROXY_BASE_URL);

--- a/src/app/api/ai/deepseek/[...slug]/route.ts
+++ b/src/app/api/ai/deepseek/[...slug]/route.ts
@@ -1,20 +1,15 @@
-import { DEEPSEEK_BASE_URL } from "@/constants/urls";
-import { createProxyHandler } from "../../create-proxy-handler";
+import { proxyHandler } from './proxy-handler';
 
-export const runtime = "edge";
+export const runtime = 'edge';
 export const preferredRegion = [
-  "cle1",
-  "iad1",
-  "pdx1",
-  "sfo1",
-  "sin1",
-  "syd1",
-  "hnd1",
-  "kix1",
+  'cle1',
+  'iad1',
+  'pdx1',
+  'sfo1',
+  'sin1',
+  'syd1',
+  'hnd1',
+  'kix1',
 ];
 
-const API_PROXY_BASE_URL = process.env.DEEPSEEK_API_BASE_URL || DEEPSEEK_BASE_URL;
-
-const handler = createProxyHandler(API_PROXY_BASE_URL);
-
-export { handler as GET, handler as POST, handler as PUT, handler as DELETE };
+export { proxyHandler as GET, proxyHandler as POST, proxyHandler as PUT, proxyHandler as DELETE };

--- a/src/app/api/ai/google/[...slug]/proxy-handler.ts
+++ b/src/app/api/ai/google/[...slug]/proxy-handler.ts
@@ -1,0 +1,10 @@
+import { GEMINI_BASE_URL } from '@/constants/urls';
+import { createProxyHandler } from '../../create-proxy-handler';
+
+const API_PROXY_BASE_URL = process.env.GOOGLE_API_BASE_URL || GEMINI_BASE_URL;
+
+export const proxyHandler = createProxyHandler(API_PROXY_BASE_URL, {
+  headers: (req) => ({
+    'x-goog-api-key': req.headers.get('x-goog-api-key') || '',
+  }),
+});

--- a/src/app/api/ai/google/[...slug]/route.ts
+++ b/src/app/api/ai/google/[...slug]/route.ts
@@ -1,21 +1,15 @@
-import { GEMINI_BASE_URL } from "@/constants/urls";
-import { createProxyHandler } from "../../create-proxy-handler";
+import { proxyHandler } from './proxy-handler';
 
-export const runtime = "edge";
+export const runtime = 'edge';
 export const preferredRegion = [
-  "cle1",
-  "iad1",
-  "pdx1",
-  "sfo1",
-  "sin1",
-  "syd1",
-  "hnd1",
-  "kix1",
+  'cle1',
+  'iad1',
+  'pdx1',
+  'sfo1',
+  'sin1',
+  'syd1',
+  'hnd1',
+  'kix1',
 ];
 
-// Note: Google's provider uses GEMINI_BASE_URL in constants
-const API_PROXY_BASE_URL = process.env.GOOGLE_API_BASE_URL || GEMINI_BASE_URL;
-
-const handler = createProxyHandler(API_PROXY_BASE_URL);
-
-export { handler as GET, handler as POST, handler as PUT, handler as DELETE };
+export { proxyHandler as GET, proxyHandler as POST, proxyHandler as PUT, proxyHandler as DELETE };

--- a/src/hooks/useDeepResearch.ts
+++ b/src/hooks/useDeepResearch.ts
@@ -73,7 +73,7 @@ function useDeepResearch() {
     for await (const part of result.fullStream) {
       if (part.type === "text-delta") {
         thinkTagStreamProcessor.processChunk(
-          part.textDelta,
+          part.text,
           (data) => {
             content += data;
             updateQuestions(content);
@@ -108,7 +108,7 @@ function useDeepResearch() {
     for await (const part of result.fullStream) {
       if (part.type === "text-delta") {
         thinkTagStreamProcessor.processChunk(
-          part.textDelta,
+          part.text,
           (data) => {
             content += data;
             updateReportPlan(content);
@@ -158,7 +158,7 @@ function useDeepResearch() {
         if (part.type === "text-delta") {
           thinkTagStreamProcessor.processChunk(
             
-            part.textDelta,
+            part.text,
             (data) => {
               content += data;
               updateTask(query, { learning: content });
@@ -367,7 +367,7 @@ function useDeepResearch() {
               if (part.type === "text-delta") {
                 thinkTagStreamProcessor.processChunk(
                   
-                  part.textDelta,
+                  part.text,
                   (data) => {
                     content += data;
                     updateTask(item.query, { learning: content });
@@ -380,13 +380,14 @@ function useDeepResearch() {
                 
                 reasoning += (part as any).textDelta;
               } else if (part.type === "source") {
-                
-                sources.push(part.source);
+                if (part.sourceType === "url") {
+                  sources.push({ url: part.url, title: part.title });
+                }
               } else if (part.type === "finish") {
-                
-                if (part.providerMetadata?.google) {
-                  
-                  const { groundingMetadata } = part.providerMetadata.google;
+                const finishPart = part as any;
+
+                if (finishPart.providerMetadata?.google) {
+                  const { groundingMetadata } = finishPart.providerMetadata.google;
                   const googleGroundingMetadata =
                     groundingMetadata as GoogleGenerativeAIProviderMetadata["groundingMetadata"];
                   if (googleGroundingMetadata?.groundingSupports) {
@@ -404,8 +405,7 @@ function useDeepResearch() {
                       }
                     );
                   }
-                  
-                } else if (part.providerMetadata?.openai) {
+                } else if (finishPart.providerMetadata?.openai) {
                   // Fixed the problem that OpenAI cannot generate markdown reference link syntax properly in Chinese context
                   content = content.replaceAll("【", "[").replaceAll("】", "]");
                 }
@@ -572,7 +572,7 @@ function useDeepResearch() {
       if (part.type === "text-delta") {
         thinkTagStreamProcessor.processChunk(
           
-          part.textDelta,
+          part.text,
           (data) => {
             content += data;
             updateFinalReport(content);

--- a/src/hooks/useKnowledge.ts
+++ b/src/hooks/useKnowledge.ts
@@ -101,7 +101,7 @@ function useKnowledge() {
         if (part.type === "text-delta") {
           thinkTagStreamProcessor.processChunk(
             
-            part.textDelta,
+            part.text,
             (data) => {
               content += data;
             },

--- a/src/utils/api/openai.ts
+++ b/src/utils/api/openai.ts
@@ -27,7 +27,7 @@ export class OpenAIProvider implements Provider {
             prompt,
             temperature: options.temperature,
             
-            maxTokens: options.maxTokens,
+            maxOutputTokens: options.maxTokens,
             abortSignal: options.signal,
           }),
           options.timeout || 60000
@@ -47,7 +47,7 @@ export class OpenAIProvider implements Provider {
         prompt,
         temperature: options.temperature,
         
-        maxTokens: options.maxTokens,
+        maxOutputTokens: options.maxTokens,
         abortSignal: options.signal,
       });
 

--- a/src/utils/api/xai.ts
+++ b/src/utils/api/xai.ts
@@ -29,7 +29,7 @@ export class XaiProvider implements Provider {
             model,
             prompt,
             temperature: options.temperature,
-            maxTokens: options.maxTokens,
+            maxOutputTokens: options.maxTokens,
           }),
           options.timeout
         )
@@ -48,7 +48,7 @@ export class XaiProvider implements Provider {
         model,
         prompt,
         temperature: options.temperature,
-        maxTokens: options.maxTokens,
+        maxOutputTokens: options.maxTokens,
       });
 
       return result.textStream;


### PR DESCRIPTION
### Motivation

- Add dedicated proxy handlers for Google (Gemini) and Deepseek to centralize proxy configuration and header handling.
- Normalize streaming payload handling to use the unified `part.text` field from the `ai` streaming API instead of `part.textDelta`.
- Improve source/finish handling to capture URL/title metadata and correctly process provider grounding metadata.
- Align provider usage with the newer `ai` SDK parameter name by replacing `maxTokens` with `maxOutputTokens` for OpenAI and xAI integrations.

### Description

- Added `proxy-handler.ts` for `google` and `deepseek` API routes and updated route files to export `proxyHandler` for `GET`, `POST`, `PUT`, and `DELETE` so proxy configuration is centralized and environment-configurable via `GOOGLE_API_BASE_URL`/`DEEPSEEK_API_BASE_URL`.
- Replaced occurrences of `part.textDelta` with `part.text` across streaming consumers in `useDeepResearch.ts`, `useKnowledge.ts`, and other streaming logic to match the `ai` stream event shape.
- Enhanced stream `source` and `finish` handling by pushing sources only when `part.sourceType === "url"` and adding `{ url, title }`, and introduced a `finishPart` variable to safely access `providerMetadata` and apply Google grounding metadata indexing and OpenAI markdown fixes.
- Updated `OpenAIProvider` and `XaiProvider` to use `maxOutputTokens` in `generateText`/`streamText` calls and adjusted related option passing.
- Minor code style/consistency edits (single-quote strings, region list formatting) and added a PDF asset `docs/deep-equity-research-one-page-summary.pdf`.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2514fd9588323b5d46aa0449f7b67)